### PR TITLE
Updated toolkit-ui to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Toolkit v0.3.2
+
+## Toolkit UI
+
+## 1. Bug Fixes
+- [tile] Changed tile brand modifiers class to `.c-tile__body` rather than `.c-tile__caption` so that it applies to all tiles rather than just the split media tiles
+
+===
+
 # Toolkit v0.3.1
 
 ## Toolkit UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 1. Bug Fixes
 - [tile] Changed tile brand modifiers class to `.c-tile__body` rather than `.c-tile__caption` so that it applies to all tiles rather than just the split media tiles
+- [select] Fixes gap in bg and border on hover state caused by duplicate `border-radius` properties.
 
 ===
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Sky Toolkit",
   "main": "toolkit.scss",
   "scripts": {
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "sky-toolkit-core": "git+ssh://git@github.com:sky-uk/toolkit-core.git#v0.3.15",
-    "sky-toolkit-ui": "git+ssh://git@github.com:sky-uk/toolkit-ui.git#v0.3.1"
+    "sky-toolkit-ui": "git+ssh://git@github.com:sky-uk/toolkit-ui.git#v0.3.2"
   }
 }


### PR DESCRIPTION
# Toolkit v0.3.2

## Toolkit UI

## 1. Bug Fixes
- [tile] Changed tile brand modifiers class to `.c-tile__body` rather than `.c-tile__caption` so that it applies to all tiles rather than just the split media tiles