### PR TITLE
1.6.0 🎉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Toolkit v1.6.0
+
+## Toolkit Core v1.5.0
+
+## 1. Fixes
+- [ie9] Improvements to `c-form-select` functionality.
+- [[Stylelint]](http://stylelint.io) Fix linting command and amend errors.
+
+## Toolkit UI v1.6.0
+
+## 1. Fixes
+- [tile] Allow `c-tile__link` to use either `<a>` or `<button>` allowing for more semantic use.
+- [c-form-select] Improvements to functionality on IE.
+- [[Stylelint]](http://stylelint.io) Fix linting command.
+
+===
+
+
 # Toolkit v1.5.0
 
 ## Toolkit Core v1.4.0

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [sky.com/toolkit](http://sky.com/toolkit) for full documentation and informa
 For rapid prototyping and static sites you can include our latest compiled CSS in the `<head>` of your page.
 
 ```
-<link rel="stylesheet" href="https://www.sky.com/assets/toolkit/v1.5.0/toolkit.css">
+<link rel="stylesheet" href="https://www.sky.com/assets/toolkit/v1.6.0/toolkit.css">
 ```
 
 **We strongly advise not to use this method in live projects**.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Sky's CSS Toolkit",
   "main": "toolkit.scss",
   "scripts": {
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit#readme",
   "dependencies": {
-    "sky-toolkit-ui": "1.5.0"
+    "sky-toolkit-ui": "1.6.0"
   }
 }


### PR DESCRIPTION
## Description
Bundle of:
1. https://github.com/sky-uk/toolkit-core/pull/164
2. https://github.com/sky-uk/toolkit-ui/pull/213

## Related Issue
https://github.com/sky-uk/toolkit-ui/issues/205

## Motivation and Context
Fixes dropdown for IE, allows for `<button>` to be used within Tiles

## How Has This Been Tested?
All tests pass

## Screenshots
See previous PRs

## Types of Changes
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
