### PR TITLE
Deprecate Gradient Mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 `sky-toolkit` follows [Semantic Versioning](http://semver.org) to help manage the impact of releasing new library versions.
 
 
+## 1.20.0
+
+### toolkit-core 1.16.0
+
+#### Deprecation Warnings
+
+The following will be removed in Toolkit@2.0.0:
+
+* [tools]
+  * Gradients: Removal of `@include background-gradient()`. Use `@include gradient-background()` instead.
+  * Page: Removal of `@include background-page()`. Use `@include page-background()` instead.
+
+If you experience any issues with these required changes, please visit https://git.io/v9b7v for next steps.
+
+
 ## 1.19.0
 
 ### toolkit-ui 1.19.0

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [sky.com/toolkit](http://sky.com/toolkit) for full individual component docu
 For rapid prototyping and static sites you can include our latest compiled CSS in the `<head>` of your page.
 
 ```
-<link rel="stylesheet" href="https://www.sky.com/assets/toolkit/v1.19.0/toolkit.css">
+<link rel="stylesheet" href="https://www.sky.com/assets/toolkit/v<version_number>/toolkit.css">
 ```
 
 **We strongly advise not to use this method in live projects**.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sky-toolkit",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Sky's CSS Toolkit",
   "main": "toolkit.scss",
   "scripts": {
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/sky-uk/toolkit#readme",
   "dependencies": {
-    "sky-toolkit-ui": "1.19.0"
+    "sky-toolkit-ui": "1.20.0"
   },
   "devDependencies": {
     "node-sass": "^4.5.0",


### PR DESCRIPTION
## Description
- Rename our mixins to prepare for 2.0 deprecation

## Related Issue
https://github.com/sky-uk/toolkit/issues/223

## Motivation and Context
Further 2.0 development

## How Has This Been Tested?
All tests pass

## Types of Changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit-core/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [x] Package version updated.
- [x] CHANGELOG.md updated.
