### PR TITLE
Protect current Masthead mobile menu

### DIFF
--- a/packages/sky-toolkit-core/utilities/_defence.scss
+++ b/packages/sky-toolkit-core/utilities/_defence.scss
@@ -107,3 +107,12 @@ body a.skycom-focus {
     max-width: 1140px !important;
   }
 }
+
+/**
+ * Repair altercations to the mobile menu made by our hidden overflow-x.
+ */
+.skycom-mobile {
+  body.skycom-fixed {
+    overflow-x: visible !important;
+  }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As we have added a hidden `overflow-x` to our body, we need to make sure
the current Masthead menu is still visible on mobile. This fixes the
bug; which is specific to iOS and Safari.

## Related Issue
<!-- Please link to the issue here. If an issue doesn't exist, please create one. -->
#259 

## Motivation and Context
<!--
  Why is this change required? What problem does it solve? What program is it
  supporting (if any)?
-->
Currently affecting current Masthead consumers who are also using Toolkit 2.0

## How Has This Been Tested?
<!--
  Please describe in detail how you tested your changes.

  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->
Tested on sky.com in both browsers affected and unaffected.

## Markup
<!-- If appropriate, please provide markup to compliment your changes. -->
N/A

## Screenshots
<!-- If appropriate, please provide screenshots. -->

Here are some fixed screenshots:
![screen shot 2017-07-25 at 14 23 55](https://user-images.githubusercontent.com/7349341/28577814-bb90cfb2-714f-11e7-9b7f-4a9ede096af0.png)
![screen shot 2017-07-25 at 14 24 30](https://user-images.githubusercontent.com/7349341/28577817-bcf17a96-714f-11e7-8347-5939c30273f3.png)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
