### PR TITLE
Price and Costing adjustments to allow footnote symbols

### DIFF
--- a/packages/sky-toolkit-ui/components/_costing.scss
+++ b/packages/sky-toolkit-ui/components/_costing.scss
@@ -6,7 +6,7 @@
 @import "sky-toolkit-core/tools";
 
 // Settings
-$costing-spacing: 5px;
+$costing-spacing: $global-spacing-unit-tiny;
 
 // Dependencies (Optional)
 // =========================================== */
@@ -24,8 +24,8 @@ $costing-spacing: 5px;
 /**
  * Costing
  *
- * 1. We need to use non-standard font sizing at different breakpoints in order to align various
- *    blocks of text in this component
+ * 1. We need to use non-standard font sizing at different breakpoints in order
+ *    to align various blocks of text in this component
  */
 .c-costing {
   @include rem(14px); /* [1] */
@@ -41,8 +41,9 @@ $costing-spacing: 5px;
  * 1. We'll be positioning children relative to this element
  * 2. Non-standard line height to align various text nodes
  * 3. Fractional values (pence) display smaller than main values (pounds)
- * 4. Position fractional values to the top right of the price. Magic number for `top` value
- *    is unfortunate but necessary to align with line-height of parent
+ * 4. Position fractional values to the top right of the price.
+ *    Magic number for `top` value is unfortunate but necessary to align with
+ *    line-height of parent
  */
 .c-costing__price {
   @include rem(36px);
@@ -97,31 +98,42 @@ $costing-spacing: 5px;
   ============================================ */
 
 /**
- * Offer Costing
- *
- * 1. Apply the offer colouring to the price
- * 2. Striked prices on offers are displayed above the price, so need to be on a new line while
- *    maintaining width for the strikethrough line.
+ * Costing Offer
  */
 .c-costing--offer {
-  .c-costing__price {
-    color: color(offer); /* [1] */
+  /**
+   * Apply offer colors to relevent elements
+   */
+  .c-costing__price,
+  .c-price__symbol {
+    color: color(offer);
   }
 
+  /**
+   * Striked prices on offers are displayed above the price, so need to be on a
+   * new line while maintaining width for the strikethrough line.
+   */
   .c-costing__strike {
     margin-left: 0;
-    display: table; /* [2] */
+    display: table;
+  }
+
+  /**
+   * Offer amounts should be placed on own line
+   */
+  .c-costing__offer-amount {
+    display: block;
   }
 }
 
 /**
- * Smaller Costing
- *
- * 1. On smaller costs, suffixes don't display beneath fractional values, so we realign line-height
- *    and create additonal spacing
- * 2. Fractional values don't need offsetting for smaller prices
+ * Costing Small
  */
 .c-costing--small {
+  /**
+   *  1. On smaller costs, suffixes don't display beneath fractional values, so
+   *     we realign line-height and create additonal spacing
+   */
   .c-costing__price {
     @include rem(22px);
     font-weight: bold;
@@ -130,13 +142,77 @@ $costing-spacing: 5px;
     @include mq($from: medium) {
       @include rem(28px);
     }
-
-    &.c-price--fractional {
-      margin-right: 1em; /* [1] */
-    }
   }
 
+  /**
+   * Fractional values don't need offsetting for smaller prices
+   */
   .c-price__fractional {
-    top: 0; /* [2] */
+    position: relative;
+    top: 0;
+    left: 0;
+    margin: 0;
+  }
+
+}
+
+/**
+ * Footnote Marker
+ *
+ * Various accommodations to the footnote symbol based on the costing modifers
+ */
+.c-costing__price--footnote {
+  /**
+   * The symbol itself is adjacent to the element with modifers, hence the use
+   * of '+'
+   * 1. Potential use of prefix text limits space above values
+   * 2. Unset any bolding applied to parent item
+   */
+  + .c-price__symbol {
+    top: -0.25em; /* [1] */
+    font-weight: normal; /* [2] */
+    position: absolute;
+    left: 100%;  /* [1] */
+
+    /* Conditional Modifiers
+      -------------------------------- */
+
+    /**
+     * @at-root and #{&} allow us to combine modifer selectors with
+     * 'c-costing__price--footnote' and apply to 'c-price__symbol'
+     */
+
+    /**
+     * Price has fraction
+     *
+     * Fractionals take the form of an absolutely positioned number set to two
+     * decimal places - we account for their spacing by adjusting our left value
+     * by 2 characters
+     *
+     * Compiles to:
+     * .c-costing__price--fraction.c-costing__price--footnote + .c-price__symbol
+     */
+    @at-root .c-costing__price--fraction#{&} {
+      left: calc(100% + 2ch); /* [1] */
+    }
+
+    /**
+     * Small display
+     *
+     * No additional absolutely positioned elements when small so we reset
+     * symbol back to the left
+     *
+     * Compiles to:
+     * .c-costing__price--small.c-costing__price--footnote + .c-price__symbol
+     */
+    @at-root .c-costing__price--small#{&} {
+      left: 100%;
+
+      /* As font size increases, symbol needs adjustment to realign with text */
+      /* stylelint-disable-next-line max-nesting-depth */
+      @include mq($from: large) {
+        top: 0; /* [4] */
+      }
+    }
   }
 }

--- a/packages/sky-toolkit-ui/components/_price.scss
+++ b/packages/sky-toolkit-ui/components/_price.scss
@@ -5,6 +5,35 @@
 // Imports
 @import "sky-toolkit-core/tools";
 
+// Settings
+$price-footnote-spacing: $global-spacing-unit-tiny;
+
+/* Base
+  ============================================ */
+
+/**
+ * Price Container
+ *
+ * Encapsulate the price when using adjoining items such as footnote
+ *
+ * 1. Context for absolutely positioned child items (footnote)
+ * 2. Element needs to calculate line-height based on children
+ *
+ */
+.c-price-container {
+  position: relative;  /* [1] */
+  display: inline-block; /* [2] */
+}
+
+/**
+ * Price Symbol
+ *
+ * The symbol is set as a sibling <sup> element.
+ */
+.c-price__symbol {
+  margin-left: $price-footnote-spacing;
+}
+
 /* Modifiers
   ============================================ */
 
@@ -12,15 +41,19 @@
  * Striked Pricing
  *
  * 1. Removes the browser-default strikethrough decoration
- * 2. Renders a diagonal line through the text from bottom left to top right
+ * 2. Apply offer color to sibling footnote marker symbol
  */
 .c-price--strike {
   position: relative;
   text-decoration: none;  /* [1] */
   color: color(grey-30);
 
-  &::after {  /* [2] */
-
+  /**
+   * Striked Pricing: Pseudo Strike
+   *
+   * Renders a diagonal line through the text from bottom left to top right
+   */
+  &::after {
     /*! autoprefixer: off */
     content: "";
     display: block;
@@ -31,5 +64,9 @@
     border-top: 1px solid color(grey-30);
     -ms-transform: rotate(-10deg);
     transform: rotate(-10deg);
+  }
+
+  + .c-price__symbol {
+    color: color(grey-30);  /* [2] */
   }
 }


### PR DESCRIPTION
## Description
Making accommodations in `Price` and `Costing` to allow for footnote symbols.

The biggest challenge was ensuring the strikethrough should only cover the numbers and not the footnote symbol, while keeping the symbol as a sibling to the pence element when absolutely positioned, as is the case in the Molecules costing context:

![screen shot 2017-08-23 at 13 32 03](https://user-images.githubusercontent.com/1849493/29616575-e389651c-8809-11e7-858d-89f73cc177d3.png)

^ In `costing`: 22 pence is absolutely positioned to fit over the "extra a month" suffix text.

## Related Issue
 #270
Related tookit-react change: https://github.com/sky-uk/toolkit-react/pull/228

## Motivation and Context
Loyalty and Rose work require the ability to pass in footnotes in order to caveat text. This forms part of the work to style these items and make the costing and pricing easier to maintain. 

## How Has This Been Tested?
In Chrome

## Markup

See [Codepen](https://codepen.io/steveduffin/pen/dzQELb) For all possible combos

### No Strike
```
<span class="c-price-wrapper">
   <span class="c-price c-price--fraction c-price--footnote">£15<span class="c-price__fractional">.95</span></span>
    <sup class="c-price__symbol c-text-body">*</sup>
</span>
```

### Has Strike
```
<span class="c-price-wrapper">
      <s class="c-price c-price--strike c-price--fraction c-price--footnote">£15<span class="c-price__fractional">.95</span></s>
      <sup class="c-price__symbol c-text-body">†</sup>
</span>
```

## Screenshots

### Price
![screen shot 2017-08-23 at 13 26 47](https://user-images.githubusercontent.com/1849493/29616707-46ede3e4-880a-11e7-8c19-18baf54d4f2f.png)

### Costing
![localhost-8080-costing ipad](https://user-images.githubusercontent.com/1849493/29617004-375d6174-880b-11e7-9ec9-09020847e588.png)


## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit/blob/master/_template.scss)).
- [ ] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [ ] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
