### PR TITLE
[refs #00273] Fix Roundel Safari Issues

### DIFF
--- a/packages/sky-toolkit-ui/components/_roundel.scss
+++ b/packages/sky-toolkit-ui/components/_roundel.scss
@@ -12,6 +12,8 @@ $roundel-highlight-width: 3px;
 $roundel-size: 50px;
 $roundel-size-small: $roundel-size - 10px;
 $roundel-label-size: 14px;
+$roundel-icon-size: 25px;
+$roundel-icon-size-small: 20px;
 
 /* Base
    =========================================== */
@@ -34,9 +36,27 @@ $roundel-label-size: 14px;
  *
  * Roundel's can also make use of icons as well as colours and text based labels.
  * This class should be applied to the path of the SVG that you are using.
+ *
+ * 1. In order to ensure the icon is central to the Roundel, we set a vertical
+ *    align property.
+ * 2. There is an issue in Safari mobile where the default icon size was causing
+ *    the component's height to extend to create more of an oval shape. The solution
+ *    here is to set a consistent height/width value for mobile devices.
  */
 .c-roundel__icon {
+  /*! autoprefixer: off */
   fill: color(brand);
+  height: $roundel-icon-size-small;
+  left: 0;
+  width: $roundel-icon-size-small;
+  position: relative;
+  vertical-align: middle; /* [1] */
+
+  /* [2] */
+  @include mq($from: small) {
+    height: $roundel-icon-size;
+    width: $roundel-icon-size;
+  }
 }
 
 /**
@@ -54,7 +74,8 @@ $roundel-label-size: 14px;
 .c-roundel__input {
   @include hide-visually(); /* [1] */
 
-  &:checked + .c-roundel__option::before {
+  &:checked + .c-roundel__option::before,
+  &:checked + .c-roundel__option::after {
     opacity: 1; /* [2] */
   }
 
@@ -64,7 +85,6 @@ $roundel-label-size: 14px;
 
     /* [3] */
     .c-roundel__label {
-      border: 4px solid color(white);
       font-weight: bold;
     }
   }
@@ -79,13 +99,17 @@ $roundel-label-size: 14px;
  *
  * The component that the user interacts with
  *
- * 1. As briefly covered earlier in the file we achieve the blue highlight with styles
+ * 1. In order to offset the border we need to apply top and left properties.
+ *    This is why we have -1px values for both.
+ *
+ * 2. As briefly covered earlier in the file we achieve the blue highlight with styles
  *    via the :before selector. This means we can deliver a smoother experience with
  *    transition of the highlight. By default opacity is always 0, this changes to 1
  *    when the user checks the roundel.
-
- * 2. In order to offset the border we need to apply top and left properties.
- *    This is why we have -1px values for both.
+ *
+ * 3. The ::after selector is required here as an alternative to a previous
+ *    implementation of the border property against the base of the
+ *    .c-roundel__option  component. This style handles the inner white border.
  */
 .c-roundel__option {
   /*! autoprefixer: off */
@@ -99,27 +123,42 @@ $roundel-label-size: 14px;
   transition: all 0.25s linear;
 
   @include mq($from: small) {
-    height: $roundel-size;
-    width: $roundel-size;
+    height: $roundel-size - 1;
+    width: $roundel-size - 1;
   }
 
   &:hover {
     transform: scale(1);
   }
 
-  /* [1] */
-  &::before {
+  &::before,
+  &::after {
     content: "";
-    border: 3px solid color(brand);
     border-radius: 50%;
-    height: $roundel-size;
-    left: -1px; /* [2] */
+    height: $roundel-size-small;
+    width: $roundel-size-small;
+    left: -1px; /* [1] */
     top: -1px;
     opacity: 0;
     position: absolute;
-    width: $roundel-size;
-    z-index: 10;
     transition: opacity 0.25s linear;
+
+    @include mq($from: small) {
+      height: $roundel-size;
+      width: $roundel-size;
+    }
+  }
+
+  /* [2] */
+  &::before {
+    border: 3px solid color(brand);
+    z-index: z-index(2);
+  }
+
+  /* [3] */
+  &::after {
+    border: 6px solid color(white);
+    z-index: z-index(1);
   }
 }
 
@@ -142,6 +181,9 @@ $roundel-label-size: 14px;
  *
  * 1. By default the background colour for .c-roundel__label is white. But if we are rendering a
  *    colour-picker, toolkit-react will set an inline style which equates to the provided colour.
+ *
+ * 2. Roundel Colour Selectors need to have their label styled differently to accomodate a quirk
+ *    within Safari. We get around this issue by using absolute positioning rather than relative.
  */
 .c-roundel__label {
   @include font(text-smallprint);
@@ -154,9 +196,22 @@ $roundel-label-size: 14px;
   text-transform: uppercase;
   border: 4px solid transparent;
   transition: all 0.25s linear;
+  height: 100%;
+  width: 100%;
 
   @include mq($from: small) {
     @include rem($roundel-label-size);
+  }
+}
+
+/* [2] */
+.c-roundel--color {
+  .c-roundel__label {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Description
This PR fixes and issue found within safari where colour selectors weren't rendering correctly. This fix replaces the use of border for the inner white border and replaces with a workaround
using a pseudo selector that works consistently across browsers.

## Related Issue
#273 

## Motivation and Context
Fixes inconsistent issue between Safari and other browsers,


## How Has This Been Tested?
Tested browsers locally and through Virtual Machines. Wrote changes in Toolkit React locally to see the component in action.

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit/blob/master/_template.scss)).
- [ ] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [ ] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
