### PR TITLE
[refs #00276] CONTRIBUTING warning for commit template

### DIFF
--- a/.github/.git-commit-template
+++ b/.github/.git-commit-template
@@ -1,3 +1,5 @@
-[refs #00000] Subject line
+[refs #00000] Descriptive subject line
 
-Body (72 chars)
+Body adding detail and context to changes made (72 chars)
+
+# If you don't follow the critera set in `/CONTRIBUTING.md` your changes will not be approved.


### PR DESCRIPTION
## Description
Adds warning to git commit template warning users to read and follow the CONTRIBUTING guidelines when making changes to Toolkit.

## Related Issue
#276 

## Motivation and Context
We have had a number of instances of non descriptive subject lines on commit messages recently where people have not correctly followed the guidelines.

## How Has This Been Tested?
n/a

## Checklist

- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
- [ ] Package version updated.
- [ ] CHANGELOG.md updated.
