### PR TITLE
Button Icons

### DIFF
--- a/packages/sky-toolkit-ui/components/_buttons.scss
+++ b/packages/sky-toolkit-ui/components/_buttons.scss
@@ -12,6 +12,8 @@ $btn-spacing: $global-spacing-unit - $btn-border-width !default;
 $btn-border-radius: $global-border-radius !default;
 $btn-animation-speed: $global-animation-speed !default;
 $btn-animation-speed-fast: $global-animation-speed-fast !default;
+$btn-icon-size: $global-spacing-unit !default;
+$btn-icon-spacing: $global-spacing-unit-small !default;
 
 /* Base
   ============================================ */
@@ -64,6 +66,42 @@ $btn-animation-speed-fast: $global-animation-speed-fast !default;
     border: 0;
     padding: 0;
   }
+}
+
+/**
+ * Button Icon
+ *
+ * This enables an icon to be placed to the **left** of a button's text. The
+ * icon's colour will be inherited from the component's `color` attribute unless
+ * the icon has an explicit `fill` property set.
+ *
+ * Note: To avoid spacing issues, do *not* add an extra space character between
+ *       your button text and image tag.
+ *
+ * 1. Offset icon from the text baseline to be centered within
+      the component.
+ * 2. Icons must always conform to a set width and height
+ * 3. Icon should inherit it's fill from the component's text colour.
+ */
+.c-btn__icon {
+  position: relative; /* [1] */
+  top: $btn-icon-size / 2; /* [1] */
+  margin-right: $btn-icon-spacing;
+  width: $btn-icon-size; /* [2] */
+  height: $btn-icon-size; /* [2] */
+  line-height: inherit; /* [1] */
+  vertical-align: top; /* [1] */
+  fill: currentColor; /* [3] */
+}
+
+/**
+ * Button Icon - Right
+ *
+ * This enables an icon to be placed to the **right** side of a button's text.
+ */
+.c-btn__icon--right {
+  margin-left: $btn-icon-spacing;
+  margin-right: 0;
 }
 
 /* Modifiers (Cosmetic)

--- a/packages/sky-toolkit-ui/components/_buttons.scss
+++ b/packages/sky-toolkit-ui/components/_buttons.scss
@@ -108,8 +108,8 @@ $btn-icon-spacing: $global-spacing-unit-small !default;
    =========================================== */
 
 /**
-* For buttons that identify as the primary action.
-*/
+ * For buttons that identify as the primary action.
+ */
 .c-btn--primary {
   color: color(white);
   background-color: color(brand);
@@ -127,8 +127,8 @@ $btn-icon-spacing: $global-spacing-unit-small !default;
 }
 
 /**
-* For regular buttons or buttons that identify as a secondary actions.
-*/
+ * For regular buttons or buttons that identify as a secondary actions.
+ */
 .c-btn--secondary {
   color: color(brand);
   background-color: transparent;
@@ -147,9 +147,9 @@ $btn-icon-spacing: $global-spacing-unit-small !default;
 }
 
 /**
-* For regular buttons or buttons that identify as a secondary actions.
-* e.g. buttons on a dark panel
-*/
+ * For regular buttons or buttons that identify as a secondary actions.
+ * e.g. buttons on a dark panel
+ */
 .c-btn--secondary-invert {
   color: color(white);
   background-color: transparent;
@@ -186,9 +186,9 @@ $btn-icon-spacing: $global-spacing-unit-small !default;
 }
 
 /**
-* For buttons whose state is toggled when a related form or field contains
-* an error or multiple errors.
-*/
+ * For buttons whose state is toggled when a related form or field contains
+ * an error or multiple errors.
+ */
 .c-btn.is-error,
 .is-error .c-btn {
   &,
@@ -203,14 +203,14 @@ $btn-icon-spacing: $global-spacing-unit-small !default;
 }
 
 /**
-* For inputs used as a select action (`.c-select`).
-* This should be applied as a BEM Mix [A] alongside `.c-select__btn`.
-* e.g. `<span class="c-btn  c-btn--select  c-select__btn">Select</span>`
-*
-* A. https://en.bem.info/forum/4/
-*
-* 1. This should be the same value as the icon width used in _select.scss
-*/
+ * For inputs used as a select action (`.c-select`).
+ * This should be applied as a BEM Mix [A] alongside `.c-select__btn`.
+ * e.g. `<span class="c-btn  c-btn--select  c-select__btn">Select</span>`
+ *
+ * A. https://en.bem.info/forum/4/
+ *
+ * 1. This should be the same value as the icon width used in _select.scss
+ */
 .c-btn--select {
   padding-left: 40px;/* [1] */
   padding-right: 40px;/* [1] */
@@ -224,16 +224,16 @@ $btn-icon-spacing: $global-spacing-unit-small !default;
    =========================================== */
 
 /**
-* For buttons that need to display full-width.
-*/
+ * For buttons that need to display full-width.
+ */
 .c-btn--full {
   display: block;
   width: 100%;
 }
 
 /**
-* For buttons that need to display full-width on small devices only.
-*/
+ * For buttons that need to display full-width on small devices only.
+ */
 .c-btn--full\@small {
   @include mq($until: medium) {
     display: block;

--- a/packages/sky-toolkit-ui/docs/buttons.md
+++ b/packages/sky-toolkit-ui/docs/buttons.md
@@ -95,3 +95,31 @@ style.
 ```html
 <button class="c-btn c-btn--primary is-error">Error button</button>
 ```
+
+## Base
+
+### Icon
+
+An icon can be placed to the **left** of a button's text by using the
+`.c-btn__icon` element class.
+
+**Note:** To avoid spacing issues, there should be **no** empty space character
+between the text and icon.
+
+```html
+<button class="c-btn c-btn--primary">
+  <img class="c-btn__icon" src="https://www.sky.com/assets/toolkit/docs/buttons/example.svg" alt="Example Icon" />Icon Button
+</button>
+```
+
+#### Icon Right
+
+An icon can also be placed to the **right** of a button's text by using the
+additional `.c-btn__icon--right` modifier class.
+
+```html
+<button class="c-btn c-btn--primary">
+  Icon (Right) Button<img class="c-btn__icon c-btn__icon--right" src="https://www.sky.com/assets/toolkit/docs/buttons/example.svg" alt="Example Icon" />
+</button>
+```
+


### PR DESCRIPTION
This PR introduces the ability for button components, `.c-btn`, to have icons, `.c-icon`, nested within them to the left of text.

## Related Issue
#284 


## Motivation and Context
As mentioned in the issue #284:

_This is a design pattern that has been spoken about recently in Sky and is going to be moving forward as a reusable design pattern across the estate. Now that the use cases are there in different projects it's time to extend the button component so that teams are able to use it rather than creating their own implementations._


## How Has This Been Tested?
Tested locally using Toolkit-react and editing the `node_modules` package directly, then transferred over to Toolkit.

## For discussion

There are a number of things I would like to get feedback on for this PR, namely:

1. I've added a variable to control the icon's size for use within buttons. It's currently set to `20px`, we will need to get a consensus on the size of this, assuming 2. is a yes.
2. Will there be a global sizing for icons? We _could_ make it work without however for consistency I believe all icons within buttons should be a set size.
3. I would have rather the `margin-right` value be a little larger, however, it was hard to justify anything other than "these are the magic numbers", so I've gone with this for now. Needs feedback from design.
4. The `_button.scss` could do with formatting a little, there's a section for `Modifiers (Cosmetic)`, then `States` and then afterwards it's back to `Modifiers (Sizing)`. Maybe not for this PR, but could do with a look over.

## Screenshots

Chrome
![buttons-chrome](https://user-images.githubusercontent.com/2808486/30684971-2f12fbee-9eab-11e7-8725-17748b6f2e1f.png)

Firefox
![buttons-firefox](https://user-images.githubusercontent.com/2808486/30684981-348ece2c-9eab-11e7-821e-1a963b9065f0.png)

Safari
![buttons-safari](https://user-images.githubusercontent.com/2808486/30684985-38ff1232-9eab-11e7-948d-b5c567b5c07f.png)

Opera
![buttons-opera](https://user-images.githubusercontent.com/2808486/30684991-3e7425ea-9eab-11e7-937e-f82f585d62a9.png)

_I still require IE testing, unfortunately my VM isn't setup for localhost. Can someone help?

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [ ] Edge
- [x] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [x] Opera
- [x] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

Browser support should be across the board, however, IE testing is still needed.

## Checklist

- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
