### PR TITLE
[refs #00286] Distinguish <button> styled as <a>

### DIFF
--- a/packages/sky-toolkit-ui/components/_link-faux.scss
+++ b/packages/sky-toolkit-ui/components/_link-faux.scss
@@ -15,8 +15,10 @@ $link-faux-border-radius: $global-border-radius;
 /**
  * Link (Faux)
  *
- * When a `<button>` needs to appear similar to a link for cosmetic reasons,
- * Link (Faux) should be used.
+ * See `c-link` for a `<button>` styled as `<a:link> `only
+ *
+ * When a `<button>` needs to appear as a hybrid of a `<a:link>` and a `<button>`
+ * for cosmetic reasons, Link (Faux) should be used.
  *
  * 1. Reset browser styles.
  * 2. Tidy aligment for when the button size needs to be modified.

--- a/packages/sky-toolkit-ui/components/_links.scss
+++ b/packages/sky-toolkit-ui/components/_links.scss
@@ -9,6 +9,28 @@
   =========================================== */
 
 /**
+ * Link
+ *
+ * Make a element look and act like an `<a:link>`. Recommended for `<button>s`
+ * that need an alterntive display.
+ *
+ * 1. Reset browser styles.
+ * 2. Force element to appear clickable.
+ * 3. Match to a:link styling.
+ */
+.c-link {
+  border: none;  /* [1] */
+  background: none;  /* [1] */
+  padding: 0;  /* [1] */
+  cursor: pointer; /* [2] */
+  color: color(brand); /* [3] */
+
+  @include hocus() {
+    text-decoration: underline; /* [3] */
+  }
+}
+
+/**
  * Link External
  *
  * Adding icons to the end of any external links

--- a/packages/sky-toolkit-ui/docs/links.md
+++ b/packages/sky-toolkit-ui/docs/links.md
@@ -29,6 +29,12 @@ The default `sky-toolkit-core` styling provides a minimal branded link with
 <a href="#">This is a default link</a>
 ```
 
+`.c-link` Applies the branded link style to an alternative element such as a `<button>`. 
+
+```html
+<button class="c-link">This is a Button styled as a link</button>
+```
+
 ---
 
 ## External


### PR DESCRIPTION
## Description

~1. Rename `c-link-faux` to highlight subtly of use case.~ 
**EDIT** Removing from scope
2. Introduce a means to style `<button>` as straight up `<a:link>`

## Related Issue
Fixes #286

## Motivation and Context
`c-link-faux` has been misused numerous times and continues to baffle devs as it's use is more nuanced than name and docs would suggest.

At the same time, we need to provide a means to style up `<button>` as `<a:link>` as if they were placed in a body of text. 

## How Has This Been Tested?
Chrome and Firefox so far

## Markup
https://codepen.io/steveduffin/pen/LzdJpj

## Screenshots
![screen shot 2017-10-16 at 14 30 16](https://user-images.githubusercontent.com/1849493/31614515-8f32ad9e-b27e-11e7-8ed3-44525abb3548.png)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All code includes full inline documentation (as per the [template](https://github.com/sky-uk/toolkit/blob/master/_template.scss)).
- [x] All code conforms to the Toolkit [coding style](https://github.com/sky-uk/toolkit/wiki/Coding-Style).
- [x] All code conforms to [WCAG 2.0 level AA Accessibility Guidelines](https://www.w3.org/TR/WCAG20/).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
