### PR TITLE
[refs #309] Adjust line-height to render more consistently across browsers

### DIFF
--- a/packages/sky-toolkit-core/settings/_typography.scss
+++ b/packages/sky-toolkit-core/settings/_typography.scss
@@ -48,7 +48,7 @@ $text: (
   text-lead: (
     small: (
       font-size: 18px,
-      line-height: 1.44
+      line-height: 1.445
     ),
     large: (
       font-size: 22px,
@@ -62,7 +62,7 @@ $text: (
     ),
     large: (
       font-size: 18px,
-      line-height: 1.44
+      line-height: 1.445
     )
   ),
   text-smallprint: (

--- a/packages/sky-toolkit-core/test/functional/tools/_typography.scss
+++ b/packages/sky-toolkit-core/test/functional/tools/_typography.scss
@@ -39,7 +39,7 @@ $test-module-area: "Tools / Typography /";
 @include test-module("#{$test-module-area} @function line-height") {
   @include test("should return a large line-height value for given key.") {
     $actual: line-height(text-body, large);
-    $expected: 1.44;
+    $expected: 1.445;
 
     @include assert-equal($actual, $expected);
   }
@@ -53,7 +53,7 @@ $test-module-area: "Tools / Typography /";
 
   @include test("should return a large line-height value if no variant is provided.") {
     $actual: line-height(text-body);
-    $expected: 1.44;
+    $expected: 1.445;
 
     @include assert-equal($actual, $expected);
   }
@@ -75,7 +75,7 @@ $test-module-area: "Tools / Typography /";
       @include expect() {
         font-size: 18px;
         font-size: 1rem;
-        line-height: 1.44;
+        line-height: 1.445;
       }
     }
   }


### PR DESCRIPTION
## Description
Currently our 1.44 value for 18px text doesn't render correctly on Chrome, rather than computing to 26px the value is rounded down to 25px.

Adjusting the value to 1.445 causes browsers to render more consistently.


## Related Issue
https://github.com/sky-uk/toolkit/issues/309


## Motivation and Context
This makes our typography more consistent.


## How Has This Been Tested?
Tested on Chrome, Safari, Firefox and IE11


## Markup
n/a


## Screenshots
n/a


## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [ ] Edge
- [x] Firefox
- [ ] IE9
- [ ] IE10
- [x] IE11
- [ ] Opera
- [x] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
