### PR TITLE
[refs #00333] Ensure overlay header remains over overlay content

### DIFF
--- a/packages/sky-toolkit-ui/components/_overlay.scss
+++ b/packages/sky-toolkit-ui/components/_overlay.scss
@@ -48,12 +48,14 @@ $overlay-header-height-small: 60px;
  * only a close button, but could be given extra children for some journeys.
  *
  * 1.  Fix the height so we can determine how much to pad the top of the content
+ * 2.  Ensure overlay header remains above overlay content
  */
 .c-overlay__header {
   top: 0;
   height: $overlay-header-height-small; /* [1] */
   padding: 0 $global-spacing-unit-small;
   text-align: right;
+  z-index: z-index(2); /* [2] */
 
   @include mq($from: medium) {
     height: $overlay-header-height-large; /* [1] */
@@ -80,11 +82,14 @@ $overlay-header-height-small: 60px;
  *
  * 1.  Pad the top of the content to allow for the overlay header
  * 2.  Make the content scrollable if it overflows
+ * 3.  Ensure overlay content remains under overlay content
  */
 .c-overlay__content {
   padding-top: $overlay-header-height-small; /* [1] */
   height: 100%; /* [2] */
   overflow-y: scroll; /* [2] */
+  position: relative;
+  z-index: z-index(1); /* [3] */
 
   @include mq($from: medium) {
     padding-top: $overlay-header-height-large; /* [1] */


### PR DESCRIPTION
## Description
Fixes a problem where the content would scroll over the header if it's content (a hero for example) creates a new stacking context:


## Related Issue
https://github.com/sky-uk/toolkit/issues/333


## Motivation and Context
Prevent overlapping content


## How Has This Been Tested?
Tested on Chrome, Safari, Firefox and IE11, IE10, IE9


## Markup
na


## Screenshots
![screen shot 2017-12-08 at 13 33 04](https://user-images.githubusercontent.com/1419558/33768068-7c842e6c-dc1c-11e7-956d-902d24cd677c.png)


## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist
na