### PR TITLE
Back Link Typo & Removing Contributors That Have Left

### DIFF
--- a/packages/sky-toolkit-ui/docs/bezel.md
+++ b/packages/sky-toolkit-ui/docs/bezel.md
@@ -11,7 +11,6 @@ dependencies:
   - sky-toolkit-core
 contributors:
   - joebell93
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/buttons.md
+++ b/packages/sky-toolkit-ui/docs/buttons.md
@@ -14,11 +14,9 @@ dependencies:
   - sky-toolkit-core
 contributors:
   - joebell93
-  - csswizardry
   - aaronthomas
   - mrdinsdale
   - steveduffin
-  - danieljbryson
 layout: component
 ---
 
@@ -122,4 +120,3 @@ additional `.c-btn__icon--right` modifier class.
   Icon (Right) Button<img class="c-btn__icon c-btn__icon--right" src="https://www.sky.com/assets/toolkit/docs/buttons/example.svg" alt="Example Icon" />
 </button>
 ```
-

--- a/packages/sky-toolkit-ui/docs/divider.md
+++ b/packages/sky-toolkit-ui/docs/divider.md
@@ -11,7 +11,6 @@ dependencies:
   - sky-toolkit-core
 contributors:
   - joebell93
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/dropdown.md
+++ b/packages/sky-toolkit-ui/docs/dropdown.md
@@ -15,7 +15,6 @@ contributors:
   - joebell93
   - mrdinsdale
   - aaronthomas
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/forms.md
+++ b/packages/sky-toolkit-ui/docs/forms.md
@@ -11,12 +11,9 @@ dependencies:
   - sky-toolkit-core
 contributors:
   - joebell93
-  - csswizardry
   - mrdinsdale
   - skitson
   - aaronthomas
-  - danieljbryson
-  - liamhutchinson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/hero.md
+++ b/packages/sky-toolkit-ui/docs/hero.md
@@ -14,7 +14,6 @@ dependencies:
 contributors:
   - joebell93
   - mrdinsdale
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/links.md
+++ b/packages/sky-toolkit-ui/docs/links.md
@@ -14,7 +14,6 @@ dependencies:
   - sky-toolkit-core
 contributors:
   - joebell93
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/links.md
+++ b/packages/sky-toolkit-ui/docs/links.md
@@ -55,7 +55,7 @@ link styling, with an additional backward-facing chevron indicator.
 We use this inverted back link when placed over darker backgrounds.
 
 ```html { "theme": "dark" }
-<a href="#" class="c-link-back c-link--back">This is a back link</a>
+<a href="#" class="c-link-back c-link-back--invert">This is a back link</a>
 ```
 
 ---

--- a/packages/sky-toolkit-ui/docs/panel.md
+++ b/packages/sky-toolkit-ui/docs/panel.md
@@ -17,7 +17,6 @@ contributors:
   - joebell93
   - mrdinsdale
   - skitson
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/select.md
+++ b/packages/sky-toolkit-ui/docs/select.md
@@ -15,7 +15,6 @@ contributors:
   - steveduffin
   - mrdinsdale
   - skitson
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/shine.md
+++ b/packages/sky-toolkit-ui/docs/shine.md
@@ -12,7 +12,6 @@ dependencies:
   - sky-toolkit-core
 contributors:
   - joebell93
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/spinner.md
+++ b/packages/sky-toolkit-ui/docs/spinner.md
@@ -17,7 +17,6 @@ contributors:
   - joebell93
   - skitson
   - welikeideas
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/tables.md
+++ b/packages/sky-toolkit-ui/docs/tables.md
@@ -11,9 +11,7 @@ dependencies:
   - sky-toolkit-core
 contributors:
   - joebell93
-  - csswizardry
   - skitson
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/tile.md
+++ b/packages/sky-toolkit-ui/docs/tile.md
@@ -15,9 +15,7 @@ dependencies:
 contributors:
   - joebell93
   - aaronthomas
-  - csswizardry
   - mrdinsdale
-  - danieljbryson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/tooltip.md
+++ b/packages/sky-toolkit-ui/docs/tooltip.md
@@ -11,7 +11,6 @@ dependencies:
   - sky-toolkit-core
 contributors:
   - aaronthomas
-  - danieljbryson
 layout: component
 ---
 


### PR DESCRIPTION
## Description

1.Back Link Typo
   * In sky-toolkit-ui/docs/links.md, the inverted back link example should use the additional modifier class c-link-back--invert (not c-link--back)
2. Contributors
   * Remove contributors who are no longer in the company (Liam H, Dan B, Harry R)

## Related Issue
https://github.com/sky-uk/toolkit/issues/337


## How Has This Been Tested?
Locally, passes all current tests.

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
#