### PR TITLE
Conforming calendar icon to global sizing

### DIFF
--- a/packages/sky-toolkit-ui/components/_calendar.scss
+++ b/packages/sky-toolkit-ui/components/_calendar.scss
@@ -129,11 +129,14 @@ $calendar-navigation-modifiers: (
  * Calendar Navigation - Icon
  *
  * Applied directly to the SVG icon element
+ * 1. Cater for approach of using currentColor on SVGs in consuming apps.
+ * 2. Retain backwards compatibility
  */
 .c-calendar__nav-icon {
-  width: 8px;
-  height: 13px;
-  fill: color(brand);
+  width: $global-spacing-unit;
+  height: $global-spacing-unit;
+  color: color(brand); /* [1] */
+  fill: color(brand); /* [2] */
 }
 
 /**


### PR DESCRIPTION
## Description
Fix
[Calendar] Aligns calendar navigation sizing to global spacing for better compatibility with internal assets / icons. Provides alternative color prop for compatiblity with `fill:currentColor` on svgs in consuming app (see https://css-tricks.com/cascading-svg-fill-color/)

## Related Issue
#341 

## Motivation and Context
Aligning calendar across the sky estate

## How Has This Been Tested?
https://s.codepen.io/steveduffin/debug/MrYoQQ/jVkpogKXwOqA cross all modern desktop browsers, IE9 and iOS 11 

## Screenshots

Before:
![screen shot 2017-12-13 at 14 49 14](https://user-images.githubusercontent.com/1849493/33946221-1c029406-e019-11e7-9867-608b9c890f5d.png)

After:

![screen shot 2017-12-13 at 15 20 49](https://user-images.githubusercontent.com/1849493/33946268-3be4d86a-e019-11e7-8601-0aad7e7110d3.png)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] All

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
