### PR TITLE
Refactor accordion

### DIFF
--- a/packages/sky-toolkit-ui/components/_accordion.scss
+++ b/packages/sky-toolkit-ui/components/_accordion.scss
@@ -57,22 +57,27 @@ $accordion-spacing: $global-spacing-unit - $accordion-border-width;
  * Accordion labels provide context on the group and also toggles content.
  *
  * 1. Set the label's font properties.
- * 2. Allows styling of box-model properties and absolute potitioning of child/
+ * 2. Ensure consistent styling between <a> and <button>.
+ * 3. Allows styling of box-model properties and absolute potitioning of child/
  *    pseudo-elements.
- * 3. Overwrite default link styles.
- * 4. Overwrite browser interaction styles to hide outline and show pointer.
+ * 4. Overwrite default link styles.
+ * 5. Overwrite browser interaction styles to hide outline and show pointer.
  */
 .c-accordion__label {
   @include font(text-body); /* [1] */
   @include height-sizing(fixed);
+  width: 100%; /* [2] */
   padding-left: $accordion-spacing;
   padding-right: $accordion-spacing;
-  display: block; /* [2] */
-  position: relative; /* [2] */
+  display: block; /* [3] */
+  border-width: 0; /* [2] */
+  position: relative; /* [3] */
   font-weight: bold; /* [1] */
-  color: color(text); /* [3] */
-  outline: 0; /* [4] */
-  cursor: pointer; /* [4] */
+  text-align: left; /* [2] */
+  color: color(text); /* [4] */
+  background-color: transparent; /* [2] */
+  outline: 0; /* [5] */
+  cursor: pointer; /* [5] */
 
   @include hocus() {
     text-decoration: underline;

--- a/packages/sky-toolkit-ui/components/_accordion.scss
+++ b/packages/sky-toolkit-ui/components/_accordion.scss
@@ -73,7 +73,7 @@ $accordion-spacing: $global-spacing-unit - $accordion-border-width;
   border-width: 0; /* [2] */
   position: relative; /* [3] */
   font-weight: bold; /* [1] */
-  text-align: left; /* [2] */
+  text-align: inherit; /* [2] */
   color: color(text); /* [4] */
   background-color: transparent; /* [2] */
   outline: 0; /* [5] */


### PR DESCRIPTION
# Fix breaking accordion label when using a button

## Description
<!--
  Describe your changes in detail

  NOTE: This should match the CHANGELOG structure and will be used on release.
-->
Fixes breaking styling when using a button for the `accordion__label`.  It's required that we use a button in this instance for accessibility reasons.


## Related Issue
<!-- Please link to the issue here. If an issue doesn't exist, please create one. -->
#346

## Motivation and Context
<!--
  Why is this change required? What problem does it solve? What program is it
  supporting (if any)?
-->
This is to fix an accessibility issue flagged up by EsLint in the accordion that stipulates we should be using a button and not an anchor tag as the intention is not to navigate the user.  Please see [https://github.com/sky-uk/toolkit-react/pull/311](https://github.com/sky-uk/toolkit-react/pull/311)

## How Has This Been Tested?
<!--
  Please describe in detail how you tested your changes.
-->
Tested in TKR Accordion preview, please see appropriate screenshots below.


## Screenshots
<!-- If appropriate, please provide screenshots. -->
<img width="878" alt="screen shot 2017-12-18 at 14 05 52" src="https://user-images.githubusercontent.com/4982001/34109788-981c5ba8-e3fc-11e7-939c-d68b6064345b.png">
Bottom two accordion labels show appearance without the fixes applied.

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [ ] Edge
- [x] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [x] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
