### PR TITLE
Subsection Dividers

### DIFF
--- a/packages/sky-toolkit-core/tools/_divider.scss
+++ b/packages/sky-toolkit-core/tools/_divider.scss
@@ -2,6 +2,19 @@
 // TOOLS / #DIVIDER
 // =============================================================================
 
+// _divider-gradient-color-points()
+// ==============================================
+
+// Framework-only function to return a direction's gradient color points.
+
+@function _divider-gradient-color-points($direction, $color) {
+  @if $direction == "align-left" or $direction == "align-right" {
+    @return $color, rgba($color, 0);
+  } @else {
+    @return rgba($color, 0), $color, rgba($color, 0);
+  }
+}
+
 // @include divider-gradient()
 // ==============================================
 
@@ -44,7 +57,17 @@
       legacy: "top",
       position: "left bottom",
       standard: "to bottom",
-    )
+    ),
+    "align-left": (
+      legacy: "left",
+      position: "center bottom",
+      standard: "to right"
+    ),
+    "align-right": (
+      legacy: "right",
+      position: "center bottom",
+      standard: "to left"
+    ),
   );
 
   // Check if direction exists in direction map:
@@ -53,7 +76,7 @@
     $direction-legacy: map-get-deep($directions, $direction, legacy);
     $direction-standard: map-get-deep($directions, $direction, standard);
     // Fetch other gradient properties
-    $color-points: rgba($color, 0), $color, rgba($color, 0);
+    $color-points: _divider-gradient-color-points($direction, $color);
     $position: map-get-deep($directions, $direction, position);
     // Set vendor prefixes for use on legacy gradients
     $vendor-prefixes: "webkit", "moz", "ms", "o";
@@ -68,7 +91,7 @@
   }
 
   @else {
-    @warn "#{$direction}` is not a valid direction, it must be top, right, bottom or left.";
+    @warn "`#{$direction}` is not a valid direction.";
   }
 }
 
@@ -133,6 +156,6 @@
   }
 
   @else {
-    @warn "#{$direction}` is not a valid direction, it must be top, right, bottom or left.";
+    @warn "`#{$direction}` is not a valid direction.";
   }
 }

--- a/packages/sky-toolkit-ui/components/_divider.scss
+++ b/packages/sky-toolkit-ui/components/_divider.scss
@@ -81,6 +81,9 @@ $divider-modifiers: (
 /* Modifiers
   ============================================ */
 
+/* Directions
+  ---------------------------------- */
+
 /**
  * Loop to generate our suite of modifiers for each divider direction:
  *
@@ -147,4 +150,32 @@ $divider-modifiers: (
  */
 .c-divider--large {
   margin-bottom: $global-spacing-unit-large - $divider-width;
+}
+
+/* Subsection
+  ---------------------------------- */
+
+/**
+ * Applying the `--sub` modifier to any divider will remove the shadow by
+ * resetting the pseudo-element.
+ */
+.c-divider--sub {
+  &::after {
+    content: normal;
+  }
+}
+
+/**
+ * Additional alignment modifiers that are only applicable to `--sub`.
+ */
+.c-divider--sub.c-divider--align-left {
+  &::before {
+    @include divider-gradient(align-left);
+  }
+}
+
+.c-divider--sub.c-divider--align-right {
+  &::before {
+    @include divider-gradient(align-right);
+  }
 }

--- a/packages/sky-toolkit-ui/docs/components/divider.md
+++ b/packages/sky-toolkit-ui/docs/components/divider.md
@@ -54,6 +54,28 @@ and wrapped around content.
 </div>
 ```
 
+### Subsection
+
+Provides a horizontal subsection divider **without** a prominent shadow.
+
+```html
+<hr class="c-divider c-divider--sub" />
+```
+
+Subsection dividers can be aligned via additional modifiers:
+
+#### Align Left
+
+```html
+<hr class="c-divider c-divider--sub c-divider--align-left" />
+```
+
+#### Align Right
+
+```html
+<hr class="c-divider c-divider--sub c-divider--align-right" />
+```
+
 ## Spacing
 
 Extra spacing can be applied on any edge with the spacing utility classes.


### PR DESCRIPTION
# Description
New `c-divider--sub` modifier to remove the shadow from dividers. This works on **all** existing dividers by resetting the pseudo-element.

Additional modifiers can be passed to `--align-left` or `--align-right`.

## Related Issue
<!-- Please link to the issue here. If an issue doesn't exist, please create one. -->
#307

## Motivation and Context
<!--
  Why is this change required? What problem does it solve? What program is it
  supporting (if any)?
-->
Alignment with design.

## How Has This Been Tested?
<!--
  Please describe in detail how you tested your changes.

  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->
Browser tested.

## Markup
<!-- If appropriate, please provide markup to compliment your changes. -->
```
<hr class="c-divider c-divider--sub" />
<hr class="c-divider c-divider--sub c-divider--align-left" />
<hr class="c-divider c-divider--sub c-divider--align-right" />
```

## Screenshots
<!-- If appropriate, please provide screenshots. -->
![screen shot 2018-04-13 at 10 16 05](https://user-images.githubusercontent.com/7349341/38727012-bb81e240-3f03-11e8-8e36-ea927129e75e.png)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9 (falls back to standard keyline)
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
