### PR TITLE
Static cards

### DIFF
--- a/packages/sky-toolkit-ui/components/_card.scss
+++ b/packages/sky-toolkit-ui/components/_card.scss
@@ -7,6 +7,7 @@
 
 // Settings
 $card-animation-speed: $global-animation-speed-fast;
+$card-border-color: color(grey-10);
 $card-border-color-hover: #dfdfdf;
 $card-offset: 6px;
 $card-shadow-container-height: $global-spacing-unit-small;
@@ -38,7 +39,7 @@ $card-shadow-active:0 ($card-offset * 2) 18px 0 rgba(color(black), 0.25);
   transform-style: none;
   will-change: transform;
   background-color: color(white);
-  border: $global-border-width solid color(grey-10);
+  border: $global-border-width solid $card-border-color;
   transition: transform ease $card-animation-speed;
 
   /**
@@ -143,5 +144,37 @@ $card-shadow-active:0 ($card-offset * 2) 18px 0 rgba(color(black), 0.25);
   &::before,
   &::after {
     content: normal;
+  }
+}
+
+/* Modifiers
+  ============================================ */
+
+/**
+ * Static cards
+ *
+ * An optional modifier to remove all hover and focus effects from the card
+ *
+ * 1. Show the default card shadow.
+ * 2. Hide the active card shadow.
+ */
+.c-card--static {
+  will-change: auto;
+
+  @include hocus() {
+    /*! autoprefixer: off */
+    border-color: $card-border-color;
+    -ms-transform: none;
+    transform: none;
+    -ms-transform-style: none;
+    transform-style: none;
+
+    &::before {
+      opacity: 1; /* [1] */
+    }
+
+    &::after {
+      opacity: 0; /* [2] */
+    }
   }
 }


### PR DESCRIPTION
<!--
                            W A R N I N G

   Please ensure you have followed our contributing guidelines before
             attempting to merge any work into the project.

  TITLE:
    Provide a general summary of your changes in the Title above.

  LABELS:
    Please add appropriate labels to your PR.
    If you've made changes to a specific package, please make sure to select
    the corresponding label.
-->

## Description
<!--
  Describe your changes in detail

  NOTE: This should match the CHANGELOG structure and will be used on release.
-->

A new `c-card--static` modifier to disable all hover styles from the component.

## Related Issue
<!-- Please link to the issue here. If an issue doesn't exist, please create one. -->

#355 

## Motivation and Context
<!--
  Why is this change required? What problem does it solve? What program is it
  supporting (if any)?
-->

Currently, cards always have hover effects, even if they are rendered as a static element such as a `div`. We have many designs where the `card` component is used as a generic container for content rather than an interactive element such a button.

## How Has This Been Tested?
<!--
  Please describe in detail how you tested your changes.

  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->

`npm link`'d to Toolkit-React and applied to the `Card` component there. 

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
