### PR TITLE
Offer Visibility

### DIFF
--- a/packages/sky-toolkit-ui/components/_price.scss
+++ b/packages/sky-toolkit-ui/components/_price.scss
@@ -46,7 +46,6 @@ $price-footnote-spacing: $global-spacing-unit-tiny;
 .c-price--strike {
   position: relative;
   text-decoration: none;  /* [1] */
-  color: color(grey-30);
 
   /**
    * Striked Pricing: Pseudo Strike
@@ -61,12 +60,21 @@ $price-footnote-spacing: $global-spacing-unit-tiny;
     left: 0;
     top: 50%;
     right: 0;
-    border-top: 1px solid color(grey-30);
+    border-top: 1px solid;
     -ms-transform: rotate(-10deg);
     transform: rotate(-10deg);
   }
+}
+
+/**
+ * Offer Pricing
+ *
+ * Apply offer colors to relevent elements
+ */
+.c-price--offer {
+  color: color(offer);
 
   + .c-price__symbol {
-    color: color(grey-30);  /* [2] */
+    color: color(offer);
   }
 }


### PR DESCRIPTION
## Description
The business has requested that more is done to highlight offers.
This change removes the shading on strike-through pricing and introduces an offer modifier to highlight the new price. 


## Related Issue
Fixes #360

## Motivation and Context
This is the first step in a reformatting of pricing and costing as requested by design. 
More significant working will be done in separate PR, at a later date to cover costing 

## How Has This Been Tested?
Tests done in all major browsers with prototype: http://brave-varahamihira-d7feb3.bitballoon.com/


## Markup
```
<span class="c-price c-price--offer">
  £10<span class="c-price__fractional">.95</span>
</span>
```


## Screenshots
**Current:**
![screen shot 2018-01-23 at 14 38 03](https://user-images.githubusercontent.com/1849493/35281530-0d3b361a-004b-11e8-8dba-d9d212fc94d6.png)


**After:**
![screen shot 2018-01-23 at 14 10 47](https://user-images.githubusercontent.com/1849493/35281349-a12f780a-004a-11e8-9390-44c1d3a9032f.png)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [*] Chrome
- [*] Edge
- [*] Firefox
- [*] IE9
- [*] IE10
- [*] IE11
- [*] Opera
- [*] Safari
- [*] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
