### PR TITLE
Add CSS to enable inertial scrolling

### DIFF
--- a/packages/sky-toolkit-ui/components/_overlay.scss
+++ b/packages/sky-toolkit-ui/components/_overlay.scss
@@ -83,6 +83,7 @@ $overlay-header-height-small: 60px;
  * 1.  Pad the top of the content to allow for the overlay header
  * 2.  Make the content scrollable if it overflows
  * 3.  Ensure overlay content remains under overlay content
+ * 4.  Give inertial scrolling to scrollable content sitting within the overlay
  */
 .c-overlay__content {
   padding-top: $overlay-header-height-small; /* [1] */
@@ -90,6 +91,7 @@ $overlay-header-height-small: 60px;
   overflow-y: scroll; /* [2] */
   position: relative;
   z-index: z-index(1); /* [3] */
+  -webkit-overflow-scrolling: touch; /* [4] */
 
   @include mq($from: medium) {
     padding-top: $overlay-header-height-large; /* [1] */


### PR DESCRIPTION
## Description
Added CSS to enable inertial scrolling


## Related Issue
https://github.com/sky-uk/toolkit/issues/363


## Motivation and Context
Mobile devices when an overflow is set to auto or scroll the scrolling is not smooth. This was identified by a tester within the `in-page-upgrades` app.


## How Has This Been Tested?
https://codepen.io/anon/pen/ppXwgg

I also tested this within the app this was identified in and created a review app on heroku though this isn't easily accessible by everyone.

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [x] Safari
- [x] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
