### PR TITLE
Added .npmrc files to stop generating package locks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/sky-toolkit-core/.npmrc
+++ b/packages/sky-toolkit-core/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/sky-toolkit-ui/.npmrc
+++ b/packages/sky-toolkit-ui/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/sky-toolkit/.npmrc
+++ b/packages/sky-toolkit/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION

## Description
Added `.npmrc` files to stop generating package locks


## Related Issue
https://github.com/sky-uk/toolkit/issues/365


## Motivation and Context
Following the contribution guidelines for #363 when installing i encountered these files though realised they aren't adopted. I think it'd be a good idea to stop generating these to prevent this occurring for others who wish to contribute.

## How Has This Been Tested?
Locally tested after doing a git clean and a fresh install to see if the lockfiles are re-generated. 

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support
N/A

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
