### PR TITLE
Fix long label on accordion

### DIFF
--- a/packages/sky-toolkit-ui/components/_accordion.scss
+++ b/packages/sky-toolkit-ui/components/_accordion.scss
@@ -11,8 +11,9 @@ $accordion-background: transparent !default;
 $accordion-border-width: 1px;
 $accordion-border: $accordion-border-width solid color(grey-20) !default;
 $accordion-border-radius: $global-border-radius !default;
-$accordion-icon-size: 20px !default;
 $accordion-spacing: $global-spacing-unit - $accordion-border-width;
+$accordion-icon-size: 20px !default;
+$accordion-icon-offset: $accordion-spacing * 2 + $accordion-icon-size;
 
 /* Base
   ============================================ */
@@ -64,9 +65,9 @@ $accordion-spacing: $global-spacing-unit - $accordion-border-width;
  */
 .c-accordion__label {
   @include font(text-body); /* [1] */
-  @include height-sizing(fixed);
+  @include height-sizing(padding);
   padding-left: $accordion-spacing;
-  padding-right: $accordion-spacing;
+  padding-right: $accordion-icon-offset;
   display: block; /* [2] */
   position: relative; /* [2] */
   font-weight: bold; /* [1] */


### PR DESCRIPTION
## Description
Fixed accordion label overlapping when the label is too long.

set height of accordion label to expand to fit the label title and added padding to the right to not overlap the dropdown icon


## Related Issue
https://github.com/sky-uk/toolkit/issues/377

## Motivation and Context
Currently text that is too long in the label overlaps the second label.
It also overlaps the drop down arrow.

![Example](https://user-images.githubusercontent.com/5748077/36978790-63cc5fca-207d-11e8-87d0-8eb3e1a30eea.png)

## How Has This Been Tested?
I ran `toolkit-react` locally and used my branch in `toolkit` by linking it with `yarn link`.
I then tested the style changes using toolkit react's storybook feature.

## Markup
<!-- If appropriate, please provide markup to compliment your changes. -->


## Screenshots
![screen shot 2018-03-07 at 3 55 37 pm](https://user-images.githubusercontent.com/5748077/37280394-8c20ec8a-25e5-11e8-8bd9-bc4d501fd30e.png)
![screen shot 2018-03-07 at 3 50 00 pm](https://user-images.githubusercontent.com/5748077/37280395-8c39e3c0-25e5-11e8-86f0-0e506303a329.png)



## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
