### PR TITLE
Radio Button Pseodo-element Enhancement

### DIFF
--- a/packages/sky-toolkit-ui/components/_forms.scss
+++ b/packages/sky-toolkit-ui/components/_forms.scss
@@ -421,7 +421,7 @@ $form-spacing: $global-spacing-unit-small - $form-border-width;
   border: solid $form-border-width*2 transparent;
 
   .c-form-checkbox--radio & {
-    background-image: none;
+    content: normal;
   }
 }
 


### PR DESCRIPTION
## Description
[Forms] Small enhancement to change `background-image: none` to `content: normal` on the `c-form-checkbox--radio` modifier. This allows for more elaborate use of pseudo-elements on radio buttons

## Related Issue
https://github.com/sky-uk/toolkit/issues/376


## Motivation and Context
This change effectively frees up the use of pseudo-elements on radio buttons, allowing for more elaborate designs on radio buttons.

## How Has This Been Tested?
_To be added_

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
