### PR TITLE
Removing error styling from required inputs

### DIFF
--- a/packages/sky-toolkit-ui/components/_forms.scss
+++ b/packages/sky-toolkit-ui/components/_forms.scss
@@ -469,7 +469,7 @@ $form-spacing: $global-spacing-unit-small - $form-border-width;
 .c-form-select__dropdown {
   .is-error &,
   &.is-error,
-  &:invalid {
+  &:invalid:not(:required) {
     border-color: color(error);
 
     &:focus {
@@ -485,7 +485,7 @@ $form-spacing: $global-spacing-unit-small - $form-border-width;
 .c-form-checkbox__caption {
   .is-error &,
   &.is-error,
-  &:invalid {
+  &:invalid:not(:required) {
     &::before {
       border-color: color(error);
     }

--- a/packages/sky-toolkit-ui/docs/components/forms.md
+++ b/packages/sky-toolkit-ui/docs/components/forms.md
@@ -42,7 +42,7 @@ which would live within the recommended structure:
         <label class="c-form-label" for="f-firstname">
           First name <abbr title="This field is required" class="c-form-required">*</abbr>
         </label>
-        <input type="text" class="c-form-input" placeholder="e.g. Joe" name="f-firstname" id="f-firstname" />
+        <input type="text" class="c-form-input" placeholder="e.g. Joe" name="f-firstname" id="f-firstname" required />
       </li>
       <li class="c-form-list__item">
         <!-- Input, label etc. -->
@@ -89,7 +89,7 @@ as credit card inputs.
   <label class="c-form-label" for="f-firstname">
     First name <abbr title="This field is required" class="c-form-required">*</abbr>
   </label>
-  <input type="text" class="c-form-input" placeholder="e.g. Joe" name="f-firstname" id="f-firstname" aria-describedby="f-firstname-smallprint" />
+  <input type="text" class="c-form-input" placeholder="e.g. Joe" name="f-firstname" id="f-firstname" aria-describedby="f-firstname-smallprint" required />
   <p id="f-firstname-smallprint" class="c-text-smallprint" >This is smallprint explaining how this input field works and suggests what the user might enter into it.</p>
 </li>
 
@@ -97,7 +97,7 @@ as credit card inputs.
   <label class="c-form-label" for="f-email">
     Email <abbr title="This field is required" class="c-form-required">*</abbr>
   </label>
-  <input type="email" class="c-form-input" placeholder="e.g. joe@bloggs.com" name="f-email" id="f-email" />
+  <input type="email" class="c-form-input" placeholder="e.g. joe@bloggs.com" name="f-email" id="f-email" required />
 </li>
 
 <li class="c-form-list__item">
@@ -106,16 +106,16 @@ as credit card inputs.
   </label>
   <div class="o-layout o-layout--narrow">
     <div class="o-layout__item u-width-1/4@medium">
-      <input type="text" class="c-form-input c-form-inline__field" placeholder="1234" name="f-inline" id="f-inline-a" />
+      <input type="text" class="c-form-input c-form-inline__field" placeholder="1234" name="f-inline" id="f-inline-a" required />
     </div>
     <div class="o-layout__item u-width-1/4@medium">
-      <input type="text" class="c-form-input c-form-inline__field" placeholder="5678" name="f-inline" id="f-inline-b" />
+      <input type="text" class="c-form-input c-form-inline__field" placeholder="5678" name="f-inline" id="f-inline-b" required />
     </div>
     <div class="o-layout__item u-width-1/4@medium">
-      <input type="text" class="c-form-input c-form-inline__field" placeholder="9101" name="f-inline" id="f-inline-c" />
+      <input type="text" class="c-form-input c-form-inline__field" placeholder="9101" name="f-inline" id="f-inline-c" required />
     </div>
     <div class="o-layout__item u-width-1/4@medium">
-      <input type="text" class="c-form-input c-form-inline__field" placeholder="2134" name="f-inline" id="f-inline-d">
+      <input type="text" class="c-form-input c-form-inline__field" placeholder="2134" name="f-inline" id="f-inline-d" required />
     </div>
   </div>
 </li>
@@ -322,9 +322,9 @@ usually the `.c-form-list__item`. This will apply error styles to all contents
 
 <li class="c-form-list__item is-error">
   <label class="c-form-label" for="f-firstname">
-    First name
+    First name <abbr title="This field is required" class="c-form-required">*</abbr>
   </label>
-  <input type="text" class="c-form-input" placeholder="e.g. Joe" name="f-firstname" id="f-firstname" aria-describedby="f-firstname-smallprint" />
+  <input type="text" class="c-form-input" placeholder="e.g. Joe" name="f-firstname" id="f-firstname" aria-describedby="f-firstname-smallprint" required />
 </li>
 
 <!-- Within .c-form-list -->


### PR DESCRIPTION
## Description
### Fix

* [Forms] Error styling removed from inputs with `required` markup that are not modified by `is-error` state. Updated readme to reflect best practice with input markup. 

## Related Issue
#375 

## Motivation and Context
Confusion in shop journey's where user is presented with a form with required fields but has the impression that there is an error when no interaction has yet taken place. 

## How Has This Been Tested?
Using the awesome new preview mode and this here codepen
https://codepen.io/steveduffin/pen/zWNLPP

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [ ] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
