### PR TITLE
Extract Hero Text Shadow

### DIFF
--- a/packages/sky-toolkit-core/docs/settings/globals.md
+++ b/packages/sky-toolkit-core/docs/settings/globals.md
@@ -66,3 +66,4 @@ Exposed in [sky-toolkit-core/objects/container](../../objects/_container.scss).
 | `$global-shadow-blur`          | Default       | 
 | `$global-shadow-spread`        | Default       |
 | `$global-shadow`               | All of above  |
+| `$global-text-shadow`          | All of above  |

--- a/packages/sky-toolkit-core/settings/_globals.scss
+++ b/packages/sky-toolkit-core/settings/_globals.scss
@@ -46,3 +46,5 @@ $global-shadow-blur: 10px;
 $global-shadow-spread: 0;
 
 $global-shadow: unquote($global-shadow-x + " " + $global-shadow-y + " " + $global-shadow-blur + " " + $global-shadow-spread + " " + rgba($global-shadow-color, $global-shadow-intensity));
+
+$global-text-shadow: 0 0 25px rgba($global-shadow-color, 0.25), 1px 1px 1px rgba($global-shadow-color, 0.5);

--- a/packages/sky-toolkit-ui/components/_hero.scss
+++ b/packages/sky-toolkit-ui/components/_hero.scss
@@ -8,7 +8,6 @@
 // Settings
 $hero-border-width: 5px;
 $hero-border-color: rgba(color(white), 0.3);
-$hero-text-shadow: 0 0 25px rgba(color(black), 0.25), 1px 1px 1px rgba(color(black), 0.5);
 $hero-overlap: 10vh;
 
 // Dependencies (Optional)
@@ -88,7 +87,7 @@ $hero-overlap: 10vh;
   bottom: 0;
   width: 100%;
   padding: $global-spacing-unit 0;
-  text-shadow: $hero-text-shadow;
+  text-shadow: $global-text-shadow;
 }
 
 /**


### PR DESCRIPTION
## Description
If we're applying text-shadow to elements, it should be the same across the board and accessible via `$global-text-shadow`.

## Related Issue
https://github.com/sky-uk/toolkit/issues/379


## Motivation and Context
This is being used in places other than hero.

## How Has This Been Tested?
Tests pass.

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
