### PR TITLE
Fix for is-disabled styling when applied to c-select

### DIFF
--- a/packages/sky-toolkit-ui/components/_select.scss
+++ b/packages/sky-toolkit-ui/components/_select.scss
@@ -101,11 +101,11 @@ $select-animation-speed: $global-animation-speed-fast !default;
     @include focus-styles();
   }
 
-  &:hover + .c-select__btn {
+  &:hover + .c-select__btn:not(.is-disabled) {
     border-color: color(highlight);
   }
 
-  &:checked + .c-select__btn {
+  &:checked + .c-select__btn:not(.is-disabled) {
     border-color: color(brand);
 
     &::after {
@@ -122,14 +122,16 @@ $select-animation-speed: $global-animation-speed-fast !default;
 .c-select__btn:hover,
 .c-select__input:active + .c-select__btn,
 .c-select__input:checked + .c-select__btn {
-  padding-left: $select-icon-width / 2;
-  padding-right: $select-icon-width / 2 + $select-icon-width;
+  &:not(.is-disabled) {
+    padding-left: $select-icon-width / 2;
+    padding-right: $select-icon-width / 2 + $select-icon-width;
 
-  &::after {
-    /*! autoprefixer: off */
-    -ms-transform: translate(0, 0);
-    -webkit-transform: translate(0, 0);
-    transform: translate(0, 0);
+    &::after {
+      /*! autoprefixer: off */
+      -ms-transform: translate(0, 0);
+      -webkit-transform: translate(0, 0);
+      transform: translate(0, 0);
+    }
   }
 }
 

--- a/packages/sky-toolkit-ui/docs/components/select.md
+++ b/packages/sky-toolkit-ui/docs/components/select.md
@@ -57,6 +57,17 @@ the radio input's checked state being switched.
 
 ## States
 
+### Disabled
+
+By adding `.is-disabled` to `.c-select__btn`, the hoverstate is not applied and `c-btn.is-disabled` styling is applied.
+
+```html
+<label class="c-select">
+  <input type="checkbox" disabled class="c-select__input">
+  <span class="c-btn c-btn--select c-select__btn is-disabled">Disabled</span>
+</label>
+```
+
 ### Selected
 
 By adding `.is-selected` to `.c-select__input`, the tick icon becomes a cross icon.
@@ -67,6 +78,6 @@ input represents a selected option.
 ```html
 <label class="c-select">
   <input type="checkbox" class="c-select__input is-selected">
-  <span class="c-btn c-btn--select c-select__btn">Select</span>
+  <span class="c-btn c-btn--select c-select__btn">Selected</span>
 </label>
 ```


### PR DESCRIPTION
## Description
Fixes a styling bug when `is-disabled` is applied to a `c-btn` acting as a `c-select__btn`

## Related Issue
https://github.com/sky-uk/toolkit/issues/305

## Motivation and Context
Latest shop work requires select buttons to be disabled while waiting for a response from the server to stop the user from hammering the button and giving an indication that something is happening. 

Conversations with @mikejgregory have ensured this is now expected behaviour

## How Has This Been Tested?
Toolkit Preview in IE9 - 10 (more on that in a separate PR)

## Markup
```
<label class="c-select">
  <input type="checkbox" disabled class="c-select__input">
  <span class="c-btn c-btn--select c-select__btn is-disabled">Disabled</span>
</label>
```

## Screenshots

### Issue

![select copy](https://user-images.githubusercontent.com/1849493/38088573-33f64876-3354-11e8-8778-ad97e9823433.gif)

### Fix
![fix](https://user-images.githubusercontent.com/1849493/38088499-ede6daa8-3353-11e8-8606-70d573daddc7.gif)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
