### PR TITLE
Automated Deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,123 @@
+# Common Config
+# ===============================================
+
+default_build: &default_build
+  docker:
+    - image: circleci/node:8.9.4-stretch
+  working_directory: ~/toolkit
+
+# Jobs
+# ===============================================
+
 version: 2
 jobs:
   build:
-    docker:
-        - image: circleci/node:8.9.4-stretch
+    <<: *default_build
     steps:
       - checkout
-      - run: npm i
-      - run: sudo npm i -g lerna
-      - run: lerna bootstrap
+      - attach_workspace:
+          at: ~/toolkit
+      - run:
+          name: Install Dependencies
+          command: |
+            npm i
+            sudo npm i -g lerna
+            lerna bootstrap
       - run: npm run lint
       - run: npm run test
-      - run: npm run build
+      - run: npm run minify
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build
+
+  deploy:
+    <<: *default_build
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/toolkit
+      - run:
+          name: Gzip Assets
+          command: |
+            mkdir dist
+            gzip -6 build/toolkit-core.min.css
+            mv build/toolkit-core.min.css.gz dist/toolkit-core.min.css
+            gzip -6 build/toolkit.min.css
+            mv build/toolkit.min.css.gz dist/toolkit.min.css
       - store_artifacts:
-          path: build
-          prefix: build
+          path: dist
+          prefix: dist
+      - run:
+          name: Install AWS CLI
+          command: sudo apt-get -y -qq install awscli
+      - run:
+          name: Deploy Assets to S3
+          command: |
+            aws s3 cp --content-encoding 'gzip' dist/toolkit-core.min.css s3://${BUCKET}/toolkit-core/${CIRCLE_TAG}/
+            aws s3 cp --content-encoding 'gzip' dist/toolkit.min.css s3://${BUCKET}/toolkit/${CIRCLE_TAG}/
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
+
+  latest:
+    <<: *default_build
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/toolkit
+      - run:
+          name: Install AWS CLI
+          command: sudo apt-get -y -qq install awscli
+      - run:
+          name: Override `latest` Assets on S3.
+          command: |
+            aws s3 cp --content-encoding 'gzip' dist/toolkit-core.min.css s3://${BUCKET}/toolkit-core/latest/
+            aws s3 cp --content-encoding 'gzip' dist/toolkit.min.css s3://${BUCKET}/toolkit/latest/
+
+# Workflows
+# ===============================================
+
+# Define our main `build-and-deploy` workflow:
+# 1. Runs `build` for all branches and all tags.
+# 2. Runs `deploy` ONLY for tags that PREFIX with a valid Semver version number.
+#    e.g. `v1.0.0` or `v1.0.0-alpha` or `v1.0.0-beta` etc.
+# 3. Runs `latest` ONLY for tags that are a valid Semver version number.
+#    In other words, any other extra metadata applied to the end of a tag will
+#    prevent `latest` from running.
+#    e.g. `v1.0.0`
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
+          requires:
+            - build
+          filters:
+              tags:
+                only: /^v(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+).*/
+              branches:
+                ignore: /.*/
+      - latest:
+          requires:
+            - deploy
+          filters:
+              tags:
+                only: /^v(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)$/
+              branches:
+                ignore: /.*/
+
+# Notifications
+# ===============================================
+
+# Send Slack Notifications to private Toolkit Owners channel when a CircleCI
+# Workflow is triggered by a tag.
+experimental:
+  notify:
+    branches:
+      ignore: /.*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,9 +302,6 @@ the core maintainers or [Tom Davidson](@tom-davidson).
 
 ## Releases
 
->If you want to help make a start at automating this process, **please** do
-([#125](https://github.com/sky-uk/toolkit/issues/125)).
-
 1. Ensure the fully-approved PR is up to date with `develop`.
     * If necessary, run `git rebase develop` within the branch. **Avoid** using 
       GitHub's "update branch" button as it leaves us with unhelpful merge 
@@ -321,25 +318,23 @@ the core maintainers or [Tom Davidson](@tom-davidson).
         ```
         $ git log --oneline <last tag>.. -- packages/sky-toolkit-[core|ui]/
         ```
-8. Commit and push the `CHANGELOG.md` changes to `master`.
+8. Commit the `CHANGELOG.md` changes to `master`.
    * Don't worry about issue references here, a simple `"Update CHANGELOG"` or `"Update CHANGELOGs"` will do.
-9. Run `npm run dist` to generate `toolkit.min.css` and `toolkit-core.min.css`.
-    * Upload the assets of the updated packages to S3 (see maintainers Slack channel for bucket details):
-        1. Upload to `sky.com/assets/[toolkit|toolkit-core]/v[version]`.
-        2. Override `/latest`.
-    * In the "Upload" modal of S3; leave steps 1 and 2 as their default
-      settings. For step 3, you **must** ensure to set the following settings,
-      then click "Save".
-
-        | *Header*         | *Value* |
-        |------------------|---------|
-        | Content-Encoding | gzip    |
-      (If you can't see this option, you may need to scroll down within the modal)
-    * N.B. If your CSS doesn’t seem to be compiling with the expected changes,
-      run `npm run clean` and try again.
-10. Run `lerna publish`.
+9. Run `lerna publish`.
     * Be sure to read and follow the wizard very carefully, making sure to use
       the correct and appropriate patch/minor/major semver tag(s).
+10. Check the compiled assets have been published via CircleCI to S3 (this may
+    take a few minutes to propagate):
+    * For releases and pre-releases:
+        * [sky.com/assets/toolkit-core/v[version]/toolkit-core.min.css](
+          https://www.sky.com/assets/toolkit-core/v[version]/toolkit-core.min.css)
+        * [sky.com/assets/toolkit/v[version]/toolkit.min.css](
+          https://www.sky.com/assets/toolkit/v[version]/toolkit.min.css)
+    * For releases:
+        * [sky.com/assets/toolkit-core/latest/toolkit-core.min.css](
+          https://www.sky.com/assets/toolkit-core/latest/toolkit-core.min.css)
+        * [sky.com/assets/toolkit/latest/toolkit.min.css](
+          https://www.sky.com/assets/toolkit/latest/toolkit.min.css)
 11. Go to [Toolkit/Releases](https://github.com/sky-uk/toolkit/releases), and
     check the tag exists.
     * If the tag exists, congrats! Now create a [**new**

--- a/package.json
+++ b/package.json
@@ -17,12 +17,11 @@
     "build": "node-sass $npm_package_config_precision --output-style expanded $npm_package_config_paths build.scss build/toolkit.css",
     "minify:toolkit": "node-sass $npm_package_config_precision --output-style compressed $npm_package_config_paths build.scss build/toolkit.min.css",
     "minify:toolkit-core": "node-sass $npm_package_config_precision --output-style compressed $npm_package_config_paths --include-path packages/sky-toolkit-core/node_modules/ packages/sky-toolkit-core/_all.scss build/toolkit-core.min.css",
-    "dist": "npm run clean && npm run minify:toolkit-core && npm run minify:toolkit && npm run gzip",
+    "minify": "npm run clean && npm run minify:toolkit-core && npm run minify:toolkit",
     "test:preview": "mocha --compilers js:babel-core/register ./preview/test/**/*.spec.js",
     "test:toolkit-core": "cd packages/sky-toolkit-core && npm run test && cd -",
     "test:toolkit-ui": "cd packages/sky-toolkit-ui && npm run test && cd -",
     "test": "npm run test:preview && npm run test:toolkit-core && npm run test:toolkit-ui",
-    "gzip": "gzip -6 build/toolkit{,-core}.min.css && mv build/toolkit-core.min.css.gz build/toolkit-core.min.css && mv build/toolkit.min.css.gz build/toolkit.min.css",
     "preview": "webpack-dev-server -d --hot --config preview/webpack.config.js --watch"
   },
   "pre-commit": [


### PR DESCRIPTION
## Description

A new CircleCI Config to **drastically reduce** the time it takes to release Toolkit.

Our [current process](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#releases) involves manually uploading assets to s3, this is long, arduous and prone to human error. It can take up to 30 minutes, with only myself, @steveduffin and @lukewhitehouse being experienced with the process.

### Jobs

3 jobs are defined to undertake key tasks:

1. `build` - lint, test and build our SCSS files. 
    * To simplify the build process, I've added a new `npm run minify` command which is run by default. I've left `npm run build` as it's a useful command for local development.
2. `deploy` - Compress our minified assets from `build` and push to S3.
3. `latest` - Overwrite our `latest/` s3 assets with the compressed assets from `deploy`.

The order of these jobs are determined by our new workflow ⬇️

### Workflow

This updated configuration makes use of a new `build-and-deploy` Workflow to trigger the appropriate "jobs".

A `workspace` is also used to transfer artefacts (e.g. css assets) between jobs and reduce repetition of tasks.

1. For **all tags and branches**; run the `build` job. 
    ![Workflow Screenshot #1](https://user-images.githubusercontent.com/7349341/38360370-db84bc2c-38c1-11e8-8e97-3ef5ee66d93c.png)
2. For a **tag prefixed with a `v`**; run the `build` job, followed by the `deploy` job.
    ![Workflow Screenshot #2](https://user-images.githubusercontent.com/7349341/38360449-20dde7c6-38c2-11e8-920a-c16a5e9e6eb0.png)
3. For a **tag prefixed with a `v` immediately followed by a three decimal version number** (i.e. 0.0.1, no other suffix); run the `build` job, followed by the `deploy` job, finalising with the `latest` job.

### ENV & Keys

Maintainers will have access to the CircleCI settings where they can find the newly added:

* AWS Access Key ID and a Secret Access Key.
* `BUCKET` which is used to securely define our s3 bucket path.

These details will also be shared securely before merge.

## Related Issue

#125 

## Motivation and Context

Our current release process can take up to 30 minutes to manually build, release and test assets to s3. This should significantly reduce that time.

## How Has This Been Tested?

Various tags have been tested ([see comment](https://github.com/sky-uk/toolkit/pull/396#issuecomment-378891803)).

## Types of Changes

- [x] Framework/Internal
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
