### PR TITLE
Removed spread operator from tools/_functions in toolkit-core

### DIFF
--- a/packages/sky-toolkit-core/tools/_functions.scss
+++ b/packages/sky-toolkit-core/tools/_functions.scss
@@ -104,7 +104,7 @@
     @return $map;
   }
 
-  @warn "Unknown keys of `#{$keys...}` in the defined map";
+  @warn "Unknown keys of `#{$keys}` in the defined map";
   @return null;
 }
 


### PR DESCRIPTION
The @warn statement does not support the spread operator and has caused issues with some SaSS parsers (namely jekyll).

Fixes #401 