### PR TITLE
Allow Extension of Gradient Directions

### DIFF
--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -120,4 +120,4 @@ $gradient-directions: (
     type: radial,
     reverse: true
   )
-);
+) !default;


### PR DESCRIPTION
## Description

Add `!default` flag to `$gradient-directions` map to allow for extension/customisation (which we already allow for the gradients themselves)

## Related Issue

#400

## Motivation and Context

Required for internal project

## How Has This Been Tested?

All tests/builds pass

## Markup

Adding the new flag will allow us to do things like this:

```scss
$project-gradients: (
  ocean: (
    0%:   #0090D4,
    35%: #232687
  )
);

$project-gradient-directions: (
  diagon-alley: (
    legacy: "top",
    standard: "160deg",
    type: linear,
    reverse: false
  )
);

$gradients: map-merge($gradients, $project-gradients);
$gradient-directions: map-merge($gradient-directions, $project-gradient-directions);

// Usage
.c-foo {
  @include gradient-background("ocean", diagon-alley);
}
```

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
