### PR TITLE
Added button styling for accordion for accessibility purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/*.css
 npm-debug.log
 lerna-debug.log
 .vscode/
+.idea

--- a/packages/sky-toolkit-ui/components/_accordion.scss
+++ b/packages/sky-toolkit-ui/components/_accordion.scss
@@ -113,6 +113,16 @@ $accordion-icon-offset: $accordion-spacing * 2 + $accordion-icon-size;
 }
 
 /**
+ * Removes some of the default button styles when used as accordion label
+ */
+button.c-accordion__label {
+  width: 100%;
+  border: 0;
+  background: none;
+  text-align: left;
+}
+
+/**
  * Accordion Content
  *
  * The content for an accordion section, which is displayed on toggle.


### PR DESCRIPTION
## Description
In order for users to open the accordion using the space bar, the trigger needs to be a button however when a button is used it inherits some default styling. This ticket removes that default styling so buttons and anchors can be used interchangeably. 


## Related Issue
[2365](https://github.com/sky-uk/Digital-Help/issues/2365)


## Motivation and Context
Lets the accordion use buttons instead of anchor tags.

## How Has This Been Tested?
Manually built toolkit using `npm run build` then imported that into the internal storybook to test against the component. Also changed the anchor tag to a button in our internal shared react library

Browser stack. When an item in the accordion has focus, pressing the space bar should expand that section as stated [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role)


## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [x] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [ ] IE9 - storybook doesn't run 
- [ ] IE10 - storybook doesn't run 
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
