### PR TITLE
Custom Widths

### DIFF
--- a/packages/sky-toolkit-core/docs/settings/globals.md
+++ b/packages/sky-toolkit-core/docs/settings/globals.md
@@ -36,6 +36,16 @@ Exposed in [sky-toolkit-core/objects/container](../../objects/_container.scss).
 
 ---
 
+## Utilities
+
+Exposed in [sky-toolkit-core/utilities/widths](../../utilities/_widths.scss).
+
+| Variable                       | Value         |
+|--------------------------------|---------------|
+| `$global-widths`               | Default       |
+
+---
+
 ## Border
 
 | Variable                       | Value         |

--- a/packages/sky-toolkit-core/docs/utilities/widths.md
+++ b/packages/sky-toolkit-core/docs/utilities/widths.md
@@ -14,6 +14,13 @@ related:
 
 # Widths
 
+At Sky we design to a 12-column grid, however that's [not a one-size-fits-all 
+solution](https://www.smashingmagazine.com/2017/12/building-better-ui-designs-layout-grids/).
+
+When it comes to writing your layout, select one with the number of columns you
+**really need**. For example, there’s no point in using a 12-column grid if your
+layout only needs 3 or 4 columns.
+
 By default, Toolkit surfaces the following width utilities from [Supercell](https://github.com/sky-uk/supercell#usage):
 
 | Fraction | Classes                                                        |
@@ -23,6 +30,23 @@ By default, Toolkit surfaces the following width utilities from [Supercell](http
 | Thirds   | `.u-width-1/3`, `.u-width-2/3`                                 |
 | Quarters | `.u-width-1/4`, `.u-width-2/4`, `.u-width-3/4`                 |
 | Fifths   | `.u-width-1/5`, `.u-width-2/5`, `.u-width-3/5`, `.u-width-4/5` |
+| Sixths   | `.u-width-1/6`, `.u-width-2/6`, `.u-width-3/6`, `.u-width-4/6`,|
+|          | `.u-width-5/6`                                                 |
+
+The above values meet the vast majority of our use-cases, and are are completely 
+**customisable**. Override `$global-widths` to meet your project's preference:
+
+```scss
+// This would *only* generate `.u-width-×/12`s
+$global-widths: 12;
+@import "sky-toolkit-core/all";
+
+// or
+
+// This would generate *all* fractions up to `.u-width-×/12`s
+$global-widths: 1 2 3 4 5 6 7 8 9 10 11 12;
+@import "sky-toolkit-core/all";
+```
 
 These utilities aren't tied exclusively to
 [Layout](https://github.com/sky-uk/supercell#usage); they can be applied 

--- a/packages/sky-toolkit-core/settings/_globals.scss
+++ b/packages/sky-toolkit-core/settings/_globals.scss
@@ -22,6 +22,11 @@ $global-spacing-unit-large: round(2 * $global-spacing-unit);
 
 $global-container-width: 1200px !default;
 
+// Global Utilities Settings
+// ==============================================
+
+$global-widths: 1 2 3 4 5 6 !default;
+
 // Global Border Settings
 // ==============================================
 

--- a/packages/sky-toolkit-core/utilities/_widths.scss
+++ b/packages/sky-toolkit-core/utilities/_widths.scss
@@ -5,7 +5,7 @@
 // Build the grids
 // Create all of our classes for any/all breakpoints (e.g. `.u-width-1/2`).
 
-@include supercell(1 2 3 4 5);
+@include supercell($global-widths);
 
 // Create classes that take effect only at specific breakpoints
 // (e.g. `.u-width-1/3@medium`).
@@ -15,6 +15,6 @@
 
 @each $alias, $bp in $mq-breakpoints {
   @include mq($from: $bp) {
-    @include supercell(1 2 3 4 5, \@#{$alias});
+    @include supercell($global-widths, \@#{$alias});
   }
 }


### PR DESCRIPTION
## Description

Expand our default widths to `.u-width-×/6`s, with the option to override via `$global-widths`. 

See the updated documentation in this PR for further details.

## Related Issue

#390 

## Motivation and Context

There are a couple of cases to support design's 12-column grid, however adding all fractions up to twelfths creates bloat and a lot of wasted fractions (e.g. sevenths, nitnths).

This PR provides a sensible baseline (as we've done pretty well to accommodate this over the last 2.5 years) with the option to customise where needed.

For further context on this proposal, see https://github.com/sky-uk/toolkit/issues/390#issuecomment-388326973.

## How Has This Been Tested?

All existing tests pass.

## Markup

See the updated documentation in this PR

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [x] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
