### PR TITLE
Extend Spacing Utilities

### DIFF
--- a/packages/sky-toolkit-core/utilities/_spacing.scss
+++ b/packages/sky-toolkit-core/utilities/_spacing.scss
@@ -3,16 +3,12 @@
    ========================================================================== */
 
 /**
- * Utility classes to put specific spacing values onto elements. The below loop
- * will generate us a suite of classes like:
- *
- *   .u-margin-top {}
- *   .u-padding-left-large {}
- *   .u-margin-right-small {}
- *   .u-padding-all {}
+ * Utility classes to put specific spacing values onto elements, overriding any
+ * existing matching property declarations
  */
 
-/* Spacing utilities will override any matching property declarations */
+// Settings
+// ==============================================
 
 $global-spacing-directions: (
   null,
@@ -20,6 +16,14 @@ $global-spacing-directions: (
   -right,
   -bottom,
   -left,
+  -x (
+    -left,
+    -right,
+  ),
+  -y (
+    -top,
+    -bottom
+  )
 );
 
 $global-spacing-properties: (
@@ -32,28 +36,55 @@ $global-spacing-sizes: (
   -tiny: $global-spacing-unit-tiny,
   -small: $global-spacing-unit-small,
   -large: $global-spacing-unit-large,
+  -none: 0,
 ) !default;
 
+// Tools (Private / Framework Only)
+// ==============================================
+
+@mixin _global-spacing-selector ($property, $direction, $size) {
+  // If we have a `null` direction, the implication is that we want to use the
+  // respective property on "all" sides.
+  // This can be used as either `.u-margin-all` or the preferred
+  // sky-toolkit@3.0 suffix-less syntax `.u-margin`.
+  @if ($direction == null) {
+    .u-#{$property}#{$size},
+    .u-#{$property}-all#{$size} {
+      @content;
+    }
+  } @else {
+    .u-#{$property}#{$direction}#{$size} {
+      @content;
+    }
+  }
+}
+
+@mixin _global-spacing-declaration ($property, $direction, $value) {
+  #{$property}#{$direction}: $value !important;
+}
+
+// Base
+// ==============================================
+
+// The below loop will generate us a suite of classes:
+//   .u-padding, .u-padding-all {}
+//   .u-margin-top {}
+//   .u-padding-left-large {}
+//   .u-margin-right-small {}
+
 @each $property in $global-spacing-properties {
-  @each $direction in $global-spacing-directions {
-
-    // This is a bit nasty… If we have a `null` direction, the implication is that
-    // we want to use the respective property on all sides (TRBL). Accordingly,
-    // create a string of `-all` to use in our class name.
-    $all: null;
-
-    @if ($direction == null) {
-      $all: -all;
-    }
-
-    @each $size, $value in $global-spacing-sizes {
-      .u-#{$property}#{$direction}#{$all}#{$size} {
-        #{$property}#{$direction}: $value !important;
+  @each $direction-key, $direction-value in $global-spacing-directions {
+    @each $size-key, $size-value in $global-spacing-sizes {
+      @include _global-spacing-selector($property, $direction-key, $size-key) {
+        // If the `$direction-key` has nested values, loop through them too
+        @if type-of($direction-value) == list {
+          @each $direction in $direction-value {
+            @include _global-spacing-declaration($property, $direction, $size-value);
+          }
+        } @else {
+          @include _global-spacing-declaration($property, $direction-key, $size-value);
+        }
       }
-    }
-
-    .u-#{$property}#{$direction}#{$all}-none {
-      #{$property}#{$direction}: 0 !important;
     }
   }
 }


### PR DESCRIPTION
## Description
<!--
  Describe your changes in detail

  NOTE: This should match the CHANGELOG structure and will be used on release.
-->
* Add `-x` and `-y` axis spacing to the existing utilities.
* Introduce suffix-less syntax (e.g. `.u-margin`) to replace `-all` in `sky-toolkit@3.0`.

## Related Issue
<!-- Please link to the issue here. If an issue doesn't exist, please create one. -->
#423

## Motivation and Context
<!--
  Why is this change required? What problem does it solve? What program is it
  supporting (if any)?
-->
Improve ease-of-use of our spacing utilities

## How Has This Been Tested?
<!--
  Please describe in detail how you tested your changes.

  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->
All tests pass

## Markup
<!-- If appropriate, please provide markup to compliment your changes. -->
```css
.u-margin-x {
  margin-left: 20px;
  margin-right: 20px;
}

.u-padding-y {
  padding-top: 20px;
  padding-bottom: 20px;
}
```

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [x] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
