### PR TITLE
Enable display of form group <legends>

### DIFF
--- a/packages/sky-toolkit-core/docs/tools/mixins.md
+++ b/packages/sky-toolkit-core/docs/tools/mixins.md
@@ -85,6 +85,18 @@ Further reading: [Jonathan Snook's 'Hiding Content for Accessibility'](http://sn
 }
 ```
 
+Setting `$option` to `reset` will declare properties that override the original 
+styles to enable visually hidden content to be redisplayed. 
+
+Not passing any arguments will declare each value with `!important`  - useful for 
+building out a utility or override. Set `$important` to `false` to prevent this behaviour.
+
+```scss { "render": false }
+.foo {
+  @include hide-visually(reset, false);
+}
+```
+
 ---
 
 ## Hide Completely

--- a/packages/sky-toolkit-core/elements/_forms.scss
+++ b/packages/sky-toolkit-core/elements/_forms.scss
@@ -5,6 +5,7 @@
 /**
  * Semantically, we’d like all forms to be built with `<fieldset>`s and
  * `<legend>`s, but we don’t want to visually see them.
+ * Note that sky-toolkit@3.0 will use c-form-caption to limit scope on legend
  */
 fieldset {
   border: none;

--- a/packages/sky-toolkit-core/tools/_functions.scss
+++ b/packages/sky-toolkit-core/tools/_functions.scss
@@ -170,3 +170,18 @@
     @warn "Value must be a number i.e. 12, 24px etc.";
   }
 }
+
+// Private / Framework Only
+// ==============================================
+
+// _important()
+// ------------------------------------
+
+// Function to conditionally return !important rule.
+@function _important($important: true) {
+  @if $important {
+    @return " !important";
+  } @else {
+    @return null;
+  }
+}

--- a/packages/sky-toolkit-core/tools/_mixins.scss
+++ b/packages/sky-toolkit-core/tools/_mixins.scss
@@ -69,17 +69,46 @@
 
 // Visually hide content, leaving it accessible to screenreaders and ATs.
 // http://snook.ca/archives/html_and_css/hiding-content-for-accessibility
-@mixin hide-visually() {
-  /* Hiding elements visually overrides any matching property declarations */
-  border: 0 !important;
-  clip: rect(0 0 0 0) !important;
-  height: 1px !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  padding: 0 !important;
-  position: absolute !important;
-  width: 1px !important;
-  white-space: nowrap !important;
+@mixin hide-visually($option: default, $important: true) {
+  // Hiding elements visually overrides any matching property declarations
+  $default: (
+    border: 0,
+    clip: rect(0 0 0 0),
+    height: 1px,
+    margin: -1px,
+    overflow: hidden,
+    padding: 0,
+    position: absolute,
+    width: 1px,
+    white-space: nowrap,
+  );
+
+  // Override the default to re-enable display
+  $reset: (
+    clip: auto,
+    height: auto,
+    margin: 0,
+    overflow: visible,
+    position: static,
+    width: auto,
+    white-space: normal,
+  );
+
+  // Select the map to use
+  $apply-properties: $default;
+
+  @if ($option == "default") {
+    $apply-properties: $default;
+  } @else if ($option == "reset") {
+    $apply-properties: $reset;
+  } @else {
+    @warn "`#{$option}` is not valid, it must be `default` or `reset`";
+  }
+
+  // Generate rules
+  @each $prop, $value in $apply-properties {
+    #{$prop}: #{$value}#{_important($important)};
+  }
 }
 
 // @include hide-completely()

--- a/packages/sky-toolkit-ui/components/_forms.scss
+++ b/packages/sky-toolkit-ui/components/_forms.scss
@@ -33,6 +33,13 @@ $form-spacing: $global-spacing-unit-small - $form-border-width;
 /* Base
   ============================================ */
 
+/**
+ * Allow forms to be marked up semantically with a hidden top level caption
+ */
+.c-form-caption {
+  @include hide-visually(default, false);
+}
+
 /* Form List
   ---------------------------------- */
 
@@ -106,6 +113,15 @@ $form-spacing: $global-spacing-unit-small - $form-border-width;
   @include font($form-font-size, large);
   display: inline-block;
   margin-bottom: $global-spacing-unit-tiny;
+}
+
+/**
+ * Unhide a legend being used to label a group.
+ * This is a workaround until c-form-caption replaces the legend selector in core
+ */
+.c-form-label--group {
+  @include hide-visually(reset);
+  margin-bottom: $global-spacing-unit-tiny !important;
 }
 
 /* Form Text Inputs

--- a/packages/sky-toolkit-ui/docs/components/forms.md
+++ b/packages/sky-toolkit-ui/docs/components/forms.md
@@ -24,7 +24,8 @@ layout: component
 ### Form List
 
 Our forms should utilise a fieldset, descriptive legend (visually hidden but
-announced by screen readers) and a form list.
+announced by screen readers) and a form list. `c-form-caption` will be required
+in a future version of toolkit to ensure only the correct legends are hidden. 
 
 Keeping the form inputs in a list allows us to style items more consistently,
 utilise state classes more efficiently, and improve readability for users with
@@ -36,7 +37,7 @@ which would live within the recommended structure:
 ```html
 <form>
   <fieldset>
-    <legend>Example</legend>
+    <legend class="c-form-caption">Example</legend>
     <ul class="c-form-list">
       <li class="c-form-list__item">
         <label class="c-form-label" for="f-firstname">
@@ -244,12 +245,14 @@ For situations where can only select one option from a set of items, we use the
 As radio buttons and checkboxes share common styles we utilise a modifier rather
 than an entire new element.
 
+`c-form-label--group` should be added to ensure display of a group legend
+
 ```html
 <!-- Within .c-form-list -->
 
 <li class="c-form-list__item">
   <fieldset>
-    <legend class="c-form-label">Which side?</legend>
+    <legend class="c-form-label c-form-label--group">Which side?</legend>
     <label class="c-form-checkbox c-form-checkbox--radio u-margin-bottom-small">
       <input type="radio" class="c-form-checkbox__input" name="f-side" id="f-side_1" value="good">
       <span class="c-form-checkbox__caption">Good</span>
@@ -294,13 +297,13 @@ modifier to display them inline.
 ```html
 <li class="c-form-list__item">
   <fieldset>
-    <legend class="c-form-label">Which side?</legend>
+    <legend class="c-form-label c-form-label--group">Which side?</legend>
     <label class="c-form-checkbox c-form-checkbox--radio c-form-checkbox--inline">
-      <input type="radio" class="c-form-checkbox__input" name="f-side" id="f-side_1" value="good">
+      <input type="radio" class="c-form-checkbox__input" name="f-side_inline" id="f-side_inline_1" value="good">
       <span class="c-form-checkbox__caption">Good</span>
     </label>
     <label class="c-form-checkbox c-form-checkbox--radio c-form-checkbox--inline">
-      <input type="radio" class="c-form-checkbox__input" name="f-side" id="f-side_2" value="evil">
+      <input type="radio" class="c-form-checkbox__input" name="f-side_inline" id="f-side_inline_2" value="evil">
       <span class="c-form-checkbox__caption">Evil</span>
     </label>
   </fieldset>


### PR DESCRIPTION
## Description
This is a proposal for dealing with the issue of `<legends>` being forced to hide visually, when there is a valid use case for displaying them.

## Related Issue
Fixes #397

## Motivation and Context
Legends are a semantically useful way of marking up groups of controls on a form, such as a group of radio buttons or checkboxes addressing a question. 

https://www.w3.org/WAI/tutorials/forms/grouping/

We [hide `<legends>`](https://github.com/sky-uk/toolkit/blob/develop/packages/sky-toolkit-core/elements/_forms.scss#L13) with an element selector that is too broad and uses properties with high specificity ala `!important`

As the intention there is to hide just top level descriptions of forms, we should use a specific class
`c-form-caption` to allow consumers to opt in to this hide. 
To avoid any breaking changes, I'm suggesting that we introduce and encourage`c-form-caption` here despite it being somewhat redundant, and advise that we remove the `<legend>` hide in 3.0.

Until `<legend>` is removed, we need an override to revert the styling: `legend.c-form-label--group` 
`c-form-label--group` as it can be viewed as a modifier to `c-form-label` and  `legend` to make it very specially targeted at that broad selector. 
`legend.c-form-label--group` can then be removed in  3.0.

## How Has This Been Tested?
Preview app in all the browsers


## Markup
```
<form>
   <fieldset>
      <legend class="c-form-caption">Example</legend>
...

<li class="c-form-list__item">
   <fieldset>
     <legend class="c-form-label c-form-label--group">Which side?</legend>
...
```

## Screenshots

![before](https://user-images.githubusercontent.com/1849493/41278117-f02b82d4-6e20-11e8-889f-25aa7a0176cc.png)
![after](https://user-images.githubusercontent.com/1849493/41278118-f044584a-6e20-11e8-8657-927ed08a79c2.png)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [x] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
