### PR TITLE
[Modal] Hide close label on mobile

### DIFF
--- a/packages/sky-toolkit-ui/components/_modal.scss
+++ b/packages/sky-toolkit-ui/components/_modal.scss
@@ -102,3 +102,14 @@
   vertical-align: middle; /* [1] */
   margin-left: $global-spacing-unit-small; /* [2] */
 }
+
+/**
+ * Modal close button label
+ *
+ * Sits to the left of the icon, hidden on smaller screens.
+ */
+.c-modal__close-label {
+  @include mq($until: small) {
+    @include hide-visually();
+  }
+}

--- a/packages/sky-toolkit-ui/docs/components/modal.md
+++ b/packages/sky-toolkit-ui/docs/components/modal.md
@@ -25,29 +25,7 @@ By default, the Modal component is centered to the middle of the viewport, wrapp
   <div class="c-modal">
     <div class="u-text-right">
       <button class="c-link-faux c-modal__close" aria-label="Close Modal">
-        <span>Close</span>
-        <svg class="c-modal__close-icon" width="1.75em" height="1.75em" viewBox="0 0 32 32"><!--  CLOSE ICON SVG --></svg>
-      </button>
-    </div>
-    <div class="c-modal__body">
-      <!-- Whatever you want in the Modal -->
-    </div>
-  </div>
-</aside>
-```
-
-## Hiding the Close Label
-
-There are some use cases where you would want to show the close button, but without the label. To do
-so, use the existing `.u-hide-visually` utility provided in `sky-toolkit-core`. This ensures the
-label is still accessible to screen readers, but does not display in the browser.
-
-```html
-<aside class="c-modal-cover" role="dialog" aria-label="A label describing the Modal's current content" tabIndex="-1">
-  <div class="c-modal">
-    <div class="u-text-right">
-      <button class="c-link-faux c-modal__close" aria-label="Close Modal">
-        <span class="u-hide-visually">Close</span>
+        <span class="c-modal__close-label">Close</span>
         <svg class="c-modal__close-icon" width="1.75em" height="1.75em" viewBox="0 0 32 32"><!--  CLOSE ICON SVG --></svg>
       </button>
     </div>


### PR DESCRIPTION
## Description
PR to hide the close label on mobile, full description in issue mentioned below.

## Related Issue
https://github.com/sky-uk/toolkit/issues/433


## Motivation and Context
Motivation and Context can be found in the issue referenced above.

## How Has This Been Tested?
(-)

## Markup
(-)


## Screenshots
(-)


## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

**Genuinely not sure**
- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [x] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [x] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
