### PR TITLE
Scope form `.is-error` styles 🚨

### DIFF
--- a/packages/sky-toolkit-ui/components/_forms.scss
+++ b/packages/sky-toolkit-ui/components/_forms.scss
@@ -368,14 +368,10 @@ $form-spacing: $global-spacing-unit-small - $form-border-width;
   @include hide-visually();
 }
 
-/**
- * 1. Prevent caption text inheriting color by modifiers on parent, e.g is-error
- */
 .c-form-checkbox__caption {
   display: block;
   position: relative;
   margin-left: $form-checkbox-size + $form-checkbox-margin;
-  color: color(text); /* [1] */
 }
 
 .c-form-checkbox__caption::before {
@@ -453,15 +449,17 @@ $form-spacing: $global-spacing-unit-small - $form-border-width;
   =========================================== */
 
 /**
- * Errors are handled by adding the .is-error class to the field's parent –
- * usually the `.c-form-list__item`.
+ * Modify label styles
  */
-.is-error {
-  color: color(error);
+.c-form-label {
+  .is-error &,
+  &.is-error {
+    color: color(error);
+  }
 }
 
 /**
- * Change form field styles
+ * Modify form field styles
  */
 .c-form-date,
 .c-form-input,
@@ -469,6 +467,7 @@ $form-spacing: $global-spacing-unit-small - $form-border-width;
   .is-error &,
   &.is-error,
   &:invalid:not(:required) {
+    color: color(error);
     border-color: color(error);
 
     &:focus {
@@ -479,7 +478,7 @@ $form-spacing: $global-spacing-unit-small - $form-border-width;
 }
 
 /**
- * Change checkbox/radio indicator border color
+ * Modify checkbox/radio input styles
  */
 .c-form-checkbox__caption {
   .is-error &,


### PR DESCRIPTION
## Description

Previous `.is-error` styles weren't scoped to Forms and leaked across to any other element that used the class.

This also means we no longer have to set the default text colour for checkbox captions.
(sorry @steveduffin I know your PR's only been merged for 30 mins)

Note: In my original changes I grouped label, input, checkbox, and dropdown into a single selector to change the color - but this was super messy. I decided it was best to group the elements that have **all** the same shared styles instead.


## Related Issue
#425 

## Motivation and Context

Currently leaking into my own app-specific error styles 😭 

## How Has This Been Tested?

All tests pass, no visual changes to forms that use the state.

## Markup

No change to before.

## Screenshots

Here are all of the form elements with `is-error` applied.

![screencapture-0-0-0-0-8080-2018-06-18-16_10_14](https://user-images.githubusercontent.com/7349341/41545055-329444bc-7312-11e8-828c-9f063ef49f9b.png)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [x] Bug Fix *(non-breaking change which fixes an issue)*
- [ ] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
