### PR TITLE
Updates to documentation

### DIFF
--- a/packages/sky-toolkit-ui/docs/components/_template.md
+++ b/packages/sky-toolkit-ui/docs/components/_template.md
@@ -7,9 +7,6 @@ introduction: |
 source: sky-toolkit-ui/components/component-file-name
 dependencies:
   - sky-toolkit-core
-contributors:
-  - GitHub username of first contributor
-  - GitHub username of second contributor
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/bezel.md
+++ b/packages/sky-toolkit-ui/docs/components/bezel.md
@@ -9,8 +9,6 @@ introduction: |
 source: sky-toolkit-ui/components/bezel
 dependencies:
   - sky-toolkit-core
-contributors:
-  - joebell93
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/buttons.md
+++ b/packages/sky-toolkit-ui/docs/components/buttons.md
@@ -12,11 +12,6 @@ introduction: |
 source: sky-toolkit-ui/components/buttons
 dependencies:
   - sky-toolkit-core
-contributors:
-  - joebell93
-  - aaronthomas
-  - mrdinsdale
-  - steveduffin
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/calendar.md
+++ b/packages/sky-toolkit-ui/docs/components/calendar.md
@@ -10,9 +10,6 @@ introduction: |
 source: sky-toolkit-ui/components/calendar
 dependencies:
   - sky-toolkit-core
-contributors:
-  - turnbackdesign
-  - steveduffin
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/divider.md
+++ b/packages/sky-toolkit-ui/docs/components/divider.md
@@ -9,8 +9,6 @@ introduction: |
 source: sky-toolkit-ui/components/divider
 dependencies:
   - sky-toolkit-core
-contributors:
-  - joebell93
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/dropdown.md
+++ b/packages/sky-toolkit-ui/docs/components/dropdown.md
@@ -11,10 +11,6 @@ introduction: |
 source: sky-toolkit-ui/components/dropdown
 dependencies:
   - sky-toolkit-core
-contributors:
-  - joebell93
-  - mrdinsdale
-  - aaronthomas
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/forms.md
+++ b/packages/sky-toolkit-ui/docs/components/forms.md
@@ -9,11 +9,6 @@ introduction: |
 source: sky-toolkit-ui/components/forms
 dependencies:
   - sky-toolkit-core
-contributors:
-  - joebell93
-  - mrdinsdale
-  - skitson
-  - aaronthomas
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/hero.md
+++ b/packages/sky-toolkit-ui/docs/components/hero.md
@@ -11,9 +11,6 @@ source: sky-toolkit-ui/components/hero
 dependencies:
   - sky-toolkit-core
   - sky-toolkit-ui/components/shine
-contributors:
-  - joebell93
-  - mrdinsdale
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/links.md
+++ b/packages/sky-toolkit-ui/docs/components/links.md
@@ -12,8 +12,6 @@ introduction: |
 source: sky-toolkit-ui/components/links
 dependencies:
   - sky-toolkit-core
-contributors:
-  - joebell93
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/modal.md
+++ b/packages/sky-toolkit-ui/docs/components/modal.md
@@ -20,13 +20,14 @@ layout: component
 
 By default, the Modal component is centered to the middle of the viewport, wrapped within the `c-modal-cover` component. Within the Modal itself, it's Close button is positioned at the top of the Modal, above any content the consumer adds.
 
-```html
+```html { "container": [ "overlay", "flush" ] }
 <aside class="c-modal-cover" role="dialog" aria-label="A label describing the Modal's current content" tabIndex="-1">
   <div class="c-modal">
     <div class="u-text-right">
       <button class="c-link-faux c-modal__close" aria-label="Close Modal">
         <span class="c-modal__close-label">Close</span>
-        <svg class="c-modal__close-icon" width="1.75em" height="1.75em" viewBox="0 0 32 32"><!--  CLOSE ICON SVG --></svg>
+        <!-- `img` for demo purposes, please use `svg` in production -->
+        <img class="c-modal__close-icon" src="https://www.sky.com/assets/toolkit/docs/overlay/close.svg" alt="" />
       </button>
     </div>
     <div class="c-modal__body">
@@ -40,7 +41,7 @@ By default, the Modal component is centered to the middle of the viewport, wrapp
 
 When using the Modal you will want to ensure that viewport scrolling is locked. To do so you can append the existing `.u-overflow-hidden` utility provided in `sky-toolkit-core` to your `<html>` tag.
 
-```html
+```html { "render": false }
 <html class="u-overflow-hidden">
   <head></head>
   <body></body>

--- a/packages/sky-toolkit-ui/docs/components/modal.md
+++ b/packages/sky-toolkit-ui/docs/components/modal.md
@@ -7,10 +7,6 @@ introduction: |
 source: sky-toolkit-ui/components/modal
 dependencies:
   - sky-toolkit-core
-contributors:
-  - lukewhitehouse
-  - mikejgregory
-  - rbrtsmith
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/overlay.md
+++ b/packages/sky-toolkit-ui/docs/components/overlay.md
@@ -11,9 +11,6 @@ introduction: |
 source: sky-toolkit-ui/components/overlay
 dependencies:
   - sky-toolkit-core
-contributors:
-  - aaronthomas
-  - mikejgregory
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/overlay.md
+++ b/packages/sky-toolkit-ui/docs/components/overlay.md
@@ -34,12 +34,13 @@ entire viewport.
 The footer is an optional addition, which is typically used for rendering a primary call to action
 button.
 
-```html
+```html { "container": [ "overlay", "flush" ] }
 <article class="c-overlay">
   <header class="c-overlay__header">
-    <button class="c-overlay__close c-text-lead u-vertical-align-center c-link-faux">
+    <button class="c-overlay__close c-link-faux u-vertical-align-center">
       <span class="c-overlay__close-label">Close</span>
-      <svg class="c-overlay__close-icon" width="1.25em" height="1.25em" viewBox="0 0 100 100"><!--  CLOSE ICON SVG --></svg>
+      <!-- `img` for demo purposes, please use `svg` in production -->
+      <img class="c-overlay__close-icon" src="https://www.sky.com/assets/toolkit/docs/overlay/close.svg" alt="" />
     </button>
   </header>
   <div class="c-overlay__content">
@@ -59,12 +60,13 @@ You can optionally display the close button on the left side of the header by pa
 `.c-overlay--close-left` modifier. This is only to be used if extra contextal components need to be
 rendered in the right side of the header, such as a basket or continue button.
 
-```html
+```html { "container": [ "overlay", "flush" ] }
 <article class="c-overlay c-overlay--close-left">
   <header class="c-overlay__header">
-    <button class="c-overlay__close c-text-lead u-vertical-align-center c-link-faux">
+    <button class="c-overlay__close c-link-faux u-vertical-align-center">
       <span class="c-overlay__close-label">Close</span>
-      <svg class="c-overlay__close-icon" width="1.25em" height="1.25em" viewBox="0 0 100 100"><!--  CLOSE ICON SVG --></svg>
+      <!-- `img` for demo purposes, please use `svg` in production -->
+      <img class="c-overlay__close-icon" src="https://www.sky.com/assets/toolkit/docs/overlay/close.svg" alt="" />
     </button>
   </header>
   <div class="c-overlay__content">
@@ -78,16 +80,16 @@ rendered in the right side of the header, such as a basket or continue button.
 
 ## Hiding the Close Label
 
-There are some use cases where you would want to show the close button, but without the label. To do
-so, use the existing `.u-hide-visually` utility provided in `sky-toolkit-core`. This ensures the
-label is still accessible to screen readers, but does not display in the browser.
+There are some use cases where you would want to show the close button, but
+without the label.
 
-```html
-<article class="c-overlay c-overlay--close-left">
+```html { "container": [ "overlay", "flush" ] }
+<article class="c-overlay">
   <header class="c-overlay__header">
-    <button class="c-overlay__close c-text-lead u-vertical-align-center c-link-faux">
+    <button class="c-overlay__close c-link-faux u-vertical-align-center">
       <span class="c-overlay__close-label u-hide-visually">Close</span>
-      <svg class="c-overlay__close-icon" width="1.25em" height="1.25em" viewBox="0 0 100 100"><!--  CLOSE ICON SVG --></svg>
+      <!-- `img` for demo purposes, please use `svg` in production -->
+      <img class="c-overlay__close-icon" src="https://www.sky.com/assets/toolkit/docs/overlay/close.svg" alt="" />
     </button>
   </header>
   <div class="c-overlay__content">

--- a/packages/sky-toolkit-ui/docs/components/panel.md
+++ b/packages/sky-toolkit-ui/docs/components/panel.md
@@ -12,11 +12,6 @@ introduction: |
 source: sky-toolkit-ui/components/panel
 dependencies:
   - sky-toolkit-core
-contributors:
-  - aaronthomas
-  - joebell93
-  - mrdinsdale
-  - skitson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/select.md
+++ b/packages/sky-toolkit-ui/docs/components/select.md
@@ -10,11 +10,6 @@ source: sky-toolkit-ui/components/select
 dependencies:
   - sky-toolkit-core
   - sky-toolkit-ui/components/buttons
-contributors:
-  - joebell93
-  - steveduffin
-  - mrdinsdale
-  - skitson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/shine.md
+++ b/packages/sky-toolkit-ui/docs/components/shine.md
@@ -10,8 +10,6 @@ introduction: |
 source: sky-toolkit-ui/components/shine
 dependencies:
   - sky-toolkit-core
-contributors:
-  - joebell93
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/spinner.md
+++ b/packages/sky-toolkit-ui/docs/components/spinner.md
@@ -13,10 +13,6 @@ introduction: |
 source: sky-toolkit-ui/components/spinner
 dependencies:
   - sky-toolkit-core
-contributors:
-  - joebell93
-  - skitson
-  - welikeideas
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/tables.md
+++ b/packages/sky-toolkit-ui/docs/components/tables.md
@@ -9,9 +9,6 @@ introduction: |
 source: sky-toolkit-ui/components/tables
 dependencies:
   - sky-toolkit-core
-contributors:
-  - joebell93
-  - skitson
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/tile.md
+++ b/packages/sky-toolkit-ui/docs/components/tile.md
@@ -12,10 +12,6 @@ source: sky-toolkit-ui/components/tile
 dependencies:
   - sky-toolkit-core
   - sky-toolkit-ui/components/shine
-contributors:
-  - joebell93
-  - aaronthomas
-  - mrdinsdale
 layout: component
 ---
 

--- a/packages/sky-toolkit-ui/docs/components/tooltip.md
+++ b/packages/sky-toolkit-ui/docs/components/tooltip.md
@@ -9,8 +9,6 @@ introduction: |
 source: sky-toolkit-ui/components/tooltip
 dependencies:
   - sky-toolkit-core
-contributors:
-  - aaronthomas
 layout: component
 ---
 

--- a/preview/public/index.html
+++ b/preview/public/index.html
@@ -15,16 +15,12 @@
     <nav>
       <p class="c-heading-delta">Components</p>
       <div class="o-layout u-margin-bottom">
-        <div class="o-layout__item u-width-1/3@medium">
+        <div class="o-layout__item u-width-1/2@medium">
           <ul id="components-list" class="o-list-block"></ul>
         </div>
-        <div class="o-layout__item u-width-1/3@medium">
+        <div class="o-layout__item u-width-1/2@medium">
           <p class="c-text-lead">Undocumented</p>
           <ul id="components-undocumented-list" class="o-list-block"></ul>
-        </div>
-        <div class="o-layout__item u-width-1/3@medium">
-          <p class="c-text-lead">Full Page</p>
-          <ul id="components-fullpage-list" class="o-list-block"></ul>
         </div>
       </div>
     </nav>

--- a/preview/src/index.js
+++ b/preview/src/index.js
@@ -1,9 +1,8 @@
-import { components, componentsFullPage, componentsUndocumented } from './js/data';
+import { components, componentsUndocumented } from './js/data';
 import { renderHTML, renderListItems } from './js/render';
 
 import './index.scss';
 
 document.getElementById('components-list').innerHTML = renderListItems(components);
-document.getElementById('components-fullpage-list').innerHTML = renderListItems(componentsFullPage);
 document.getElementById('components-undocumented-list').innerHTML = renderListItems(componentsUndocumented);
 document.getElementById('main').innerHTML = renderHTML(components);

--- a/preview/src/js/data.js
+++ b/preview/src/js/data.js
@@ -7,6 +7,8 @@ const components = [
   'forms',
   'hero',
   'links',
+  'modal',
+  'overlay',
   'panel',
   'select',
   'shine',
@@ -29,8 +31,6 @@ const componentsUndocumented = [
   'typography',
 ];
 
-const componentsFullPage = ['modal', 'overlay'];
-
 const reduceMarkdown = comps => {
   return comps.reduce((docs, component) => {
     docs[component] = require(`sky-toolkit-ui/docs/components/${component}.md`);
@@ -40,4 +40,4 @@ const reduceMarkdown = comps => {
 
 const componentsData = reduceMarkdown(components);
 
-export { componentsData as components, componentsUndocumented, componentsFullPage };
+export { componentsData as components, componentsUndocumented };

--- a/preview/src/js/format.js
+++ b/preview/src/js/format.js
@@ -21,9 +21,19 @@ const format = () => {
       const classes = {
         flush: 'u-breakout qa-container-flush',
         tile: 'c-example--tile qa-container-tile',
+        overlay: 'u-breakout c-example--overlay qa-container-overlay',
       };
 
-      return container ? classes[container] : '';
+      const classList = containerList => {
+        if (Array.isArray(containerList)) {
+          const containerClassList = containerList.map(containerItem => classes[containerItem]);
+          return containerClassList.join(' ');
+        } else {
+          return classes[containerList];
+        }
+      };
+
+      return container ? classList(container) : '';
     };
 
     const example = `

--- a/preview/src/scss/bespoke.scss
+++ b/preview/src/scss/bespoke.scss
@@ -11,3 +11,13 @@
 .c-example--tile {
   max-width: 26em;
 }
+
+.c-example--overlay {
+  margin-bottom: $global-spacing-unit;
+
+  .c-overlay,
+  .c-modal-cover {
+    position: relative;
+    min-height: 100vh;
+  }
+}

--- a/preview/test/render.spec.js
+++ b/preview/test/render.spec.js
@@ -25,6 +25,10 @@ const testMarkdown = {
   <span id="qa-example-tile"/></span>
   \`\`\`
 
+  \`\`\`html { "container": [ "overlay", "flush" ] }
+  <span id="qa-example-overlay"/></span>
+  \`\`\`
+
   \`\`\`html { "theme": "dark" }
   <span id="qa-example-dark"/></span>
   \`\`\`
@@ -72,6 +76,13 @@ describe('Preview: Render', () => {
           .parent()
           .attr('class')
           .includes('qa-container-tile'),
+        true
+      );
+      assert.equal(
+        wrapper('#qa-example-overlay')
+          .parent()
+          .attr('class')
+          .includes('qa-container-overlay', 'qa-container-flush'),
         true
       );
     });


### PR DESCRIPTION
## Description

* Update Modal/Overlay docs to include:
  - [x] Custom containers
  - [x] Close icon sample
  - [x] `preview` support
    Note: we obviously can't render Modal/Overlay in their "true" form as they rely on `position: fixed;`. This is the closest way I can get them rendering within `preview`.
- [x] Remove contributors

## Related Issue

#362

## Motivation and Context

Improvements to docs

## How Has This Been Tested?

New tests added to support multiple containers within `preview`, existing tests pass.

## Markup

No change.

## Screenshots

### Modal

![screen shot 2018-07-03 at 09 39 56](https://user-images.githubusercontent.com/7349341/42208846-2239cfda-7ea5-11e8-86e3-01934854abd9.png)

### Overlay

![modal](https://user-images.githubusercontent.com/7349341/42208854-2696501c-7ea5-11e8-9f42-cdb133f116f3.png)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [x] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Opera
- [x] Safari
- [x] Mobile Devices
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
