### PR TITLE
Implement static.skyassets.com

### DIFF
--- a/packages/sky-toolkit-core/generic/_font-face.scss
+++ b/packages/sky-toolkit-core/generic/_font-face.scss
@@ -11,12 +11,12 @@
    */
   @font-face {
     font-family: "Sky Text";
-    src: url("//www.sky.com/assets/fonts/sky-regular.woff") format("woff");
+    src: url("//static.skyassets.com/assets/fonts/sky-regular.woff") format("woff");
   }
 
   @font-face {
     font-family: "Sky Text";
-    src: url("//www.sky.com/assets/fonts/sky-medium.woff") format("woff");
+    src: url("//static.skyassets.com/assets/fonts/sky-medium.woff") format("woff");
     font-weight: bold;
   }
 }

--- a/packages/sky-toolkit-core/index.js
+++ b/packages/sky-toolkit-core/index.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-var, prefer-template */
 var version = require('./package.json').version;
 
-var cdnUrl = '//www.sky.com/assets/toolkit-core/v' + version + '/toolkit-core.min.css';
+var cdnUrl = '//static.skyassets.com/assets/toolkit-core/v' + version + '/toolkit-core.min.css';
 var cdnTag = '<link rel="stylesheet" href="' + cdnUrl + '">';
 
 module.exports = {

--- a/packages/sky-toolkit/index.js
+++ b/packages/sky-toolkit/index.js
@@ -4,7 +4,7 @@ var skyToolkitCore = require('sky-toolkit-core');
 
 var version = require('./package.json').version;
 
-var cdnUrl = '//www.sky.com/assets/toolkit/v' + version + '/toolkit.min.css';
+var cdnUrl = '//static.skyassets.com/assets/toolkit/v' + version + '/toolkit.min.css';
 var cdnTag = '<link rel="stylesheet" href="' + cdnUrl + '">';
 
 var skyToolkitCoreCdnUrl = skyToolkitCore.cdnUrl;


### PR DESCRIPTION
## Description

Switching hardcoded `//www.sky.com` to `//static.skyassets.com`, which would result in assets being served up quicker due to less akamai contention on the domain.

cc @jbwatson @jacktams 

## Related Issue

#437 

## Motivation and Context

Faster CDN performance 🚀 

## How Has This Been Tested?

URLs surface as expected

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [x] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
