### PR TITLE
Restructure Link and introduce "Close" modifier

### DIFF
--- a/packages/sky-toolkit-ui/components/_links.scss
+++ b/packages/sky-toolkit-ui/components/_links.scss
@@ -2,13 +2,17 @@
    COMPONENTS / #LINKS
    ========================================================================== */
 
+/**
+ * ⚠️ DEPRECATION WARNING
+ * The following classes will be deprecated in sky-toolkit-ui@3.0.0, please use
+ * the alternatives detailed below:
+ *   ◦ `c-link-external` → `c-link--external`
+ *   ◦ `c-link-back` → `c-link--back`
+ *   ◦ `c-link-back c-link-back--invert` → `c-link c-link--back c-link--invert`
+ */
+
 // Imports
 @import "sky-toolkit-core/tools";
-
-// Settings
-// Hardcoded values to match icon sizing ratio.
-$link-icon-width: convert-to-em(11px);
-$link-icon-height: convert-to-em(20px);
 
 /* Base
   =========================================== */
@@ -35,63 +39,110 @@ $link-icon-height: convert-to-em(20px);
   }
 }
 
-/* Link Back
+/**
+ * Link Label
+ *
+ * Note: should only be used alongside an icon modifier.
+ */
+.c-link__label {
+  @include mq($until: small) {
+    @include hide-visually();
+  }
+}
+
+/* Modifiers
+  =========================================== */
+
+/* Icons
   ---------------------------------- */
+
+/**
+ * Link Back & Link External
+ *
+ * Shared pseudo-element styling for our "chevron" icons used in both our Link
+ * Back and Link External modifiers.
+ *
+ * 1. Hard-coded values to match chevron icon sizing ratio.
+ */
+.c-link-back::before, /* ⚠️ [SEE DEPRECATION WARNING] */
+.c-link--back::before,
+.c-link-external::after, /* ⚠️ [SEE DEPRECATION WARNING] */
+.c-link--external::after {
+  content: "";
+  display: inline-block;
+  background-repeat: no-repeat;
+  background-size: contain;
+  vertical-align: text-bottom;
+  width: convert-to-em(11px); /* [1] */
+  height: convert-to-em(20px); /* [1] */
+}
 
 /**
  * Link Back
  *
- * Adding icons to the beginning of any back links
+ * Adding a `<` to the beginning of any back links
  *
- * 1. `.c-link-back` currently uses an inline Base64 png chevron icon.
+ * 1. Currently uses an inline Base64 png chevron icon.
  *    This will eventually be replaced by SVG.
  */
-.c-link-back {
+.c-link-back, /* ⚠️ [SEE DEPRECATION WARNING] */
+.c-link--back {
   &::before {
-    content: "";
-    display: inline-block;
     background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACMAAABACAMAAACnZz6fAAAAflBMVEUAAAAAjOkAc8YAdMYAecoAdMYAc8YAdMYAc8YAc8YAd8kAd8kAfswAc8YAdMYAdMYAdMYAc8YAdMYAdMcAdcgAd8gAdskAd8kAe8wAe9AAgtAAc8YAc8YAdMYAc8YAdcgAdccAdckAdcgAdMcAdMYAdMYAdMcAdMUAd8YAc8XwTFXoAAAAKXRSTlMABPrOG+3c6ePAMCQR1vXn4NJaUywoIBcUDQnxyLitTEE7NaahsntuR62QE84AAADlSURBVEjHjdbXEoIwEIVhFESlCEi3d837v6AzJl4e/uz1N0PJ5uwGk5WE8TYAsjDGvJkYU0+QZml+tdakdSTMNCmQpCtLqgFJ3kvSlUgiR+JIk9iblJ0kfW7JSpOhciRFUmiShZYsWyaNJOPBkoUHSTRZO3KTZOfI3oNcNTlastFk9icXTZ5MTpbMP0zOmtz9Sa3JA0nwMram8qFAwoaf5YremT+M/yGfBZ8p9wb3GPeqZ8/z3dE1AuK7zJnA2cIZxVnHmcnZqyvKMcN5FvBM4dnEM45nJc9cnt28A/Au4beT8G7zBQdzSZh10g/3AAAAAElFTkSuQmCC"); /* [1] */
-    background-repeat: no-repeat;
-    background-size: contain;
-    vertical-align: text-bottom;
     margin-right: $global-spacing-unit-small;
-    width: $link-icon-width;
-    height: $link-icon-height;
   }
 }
 
-/**
- * Link Back (Invert)
- *
- * For back links used in dark areas of UI.
- */
-.c-link-back--invert {
-  color: color(white);
-
+/* When Link Back is used alongside `.c-link--invert` */
+.c-link-back--invert, /* ⚠️ [SEE DEPRECATION WARNING] */
+.c-link--back.c-link--invert {
   &::before {
     background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACMAAABACAMAAACnZz6fAAAAh1BMVEUAAAD///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////9qkf8RAAAALHRSTlMA++zi3QXm2dEnIxsUEQn49OnUzMNXUDAYAvC8trGpokE7NS4rHw17bl1KR26dH2oAAADvSURBVEjHpdbXDoJAEIVhVETsXVDsgJX3fz5Jdrw8+5Ow119C2Zk5E3hPEofbAEi3qqqXl+Q1qc/OQwpHqkyT4dKR9VSTyJFYk5GR1USTHpLSyCCVZBwaGSMJNUkHRkokvZEkkxWT2JFoKMnUyNJD1kYKSR5GurkmGyOJJDMjh3srkjmyuGlyRNL/k6smJ0fmDchXk7ORjyR7I52dJpfmxNP8TyZB5Mg7aGH4WXbgneHb6R/yXfCdcm1wjQGCWuWa595hxL3MM4FnC8+o5rOOZybPXkalJJwFnCmcTZxxnJWcuZzdvAPwLtFsJ+Hd5gc3bk6uPnGoHwAAAABJRU5ErkJggg=="); /* [1] */
   }
 }
 
-/* Link External
-  ---------------------------------- */
-
 /**
- * Adding icons to the end of any external links
+ * Link External
+ *
+ * Adding a `>` icon to the end of any external links
  *
  * 1. `.c-link-external` currently uses an inline Base64 png chevron icon.
  *    This will eventually be replaced by SVG.
  */
-.c-link-external {
+.c-link-external, /* ⚠️ [SEE DEPRECATION WARNING] */
+.c-link--external {
   &::after {
-    content: "";
-    display: inline-block;
     background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACMAAABACAMAAACnZz6fAAAAflBMVEUAAAAAjOkAc8YAdMYAecoAdMYAc8YAdMYAc8YAc8YAd8kAd8kAfswAc8YAdMYAdMYAdMYAc8YAdMYAdMcAdcgAd8gAdskAd8kAe8wAe9AAgtAAc8YAc8YAdMYAc8YAdcgAdccAdckAdcgAdMcAdMYAdMYAdMcAdMUAd8YAc8XwTFXoAAAAKXRSTlMABPrOG+3c6ePAMCQR1vXn4NJaUywoIBcUDQnxyLitTEE7NaahsntuR62QE84AAADlSURBVEjHpdbXDsIwDIXhQGnppHuxaVl5/xdEIuH2x1V8/UlVE8fHSqkq8GLF9dJa+4xqrf+iSH9r24BJPYtaAcoJDaVBYQKozxagogO0CSzaCFBAqCsMyhCFFvWAEovKgVAuQO3WIC8F1IiQb9BxBBRL0HQwKBKhPaCbCO0MOhG6/tBKgB6E3muDzoQuS9BMqLboLkIKqtKmngKUOxj4FvwYkXnlcoZ8F3yn3BvcY9yrLj0/CYhvyejylhskPFt4RvGs45npMnu7AgY9ZAFmCmeTS8ZxVnLmcnbzDsC7hONOItltPoBXSZjOoXJsAAAAAElFTkSuQmCC"); /* [1] */
-    background-repeat: no-repeat;
-    background-size: contain;
-    vertical-align: text-bottom;
     margin-left: $global-spacing-unit-small;
-    width: $link-icon-width;
-    height: $link-icon-height;
   }
+}
+
+/**
+ * Link Close
+ *
+ * Adding a `×` icon to the end of any close links
+ */
+.c-link--close {
+  color: color(text);
+
+  &::after {
+    display: inline-block;
+    margin-left: $global-spacing-unit-tiny;
+    vertical-align: sub;
+    content: "\2715"; // ×
+    font-size: 1.5em;
+  }
+}
+
+/* Cosmetic
+  ---------------------------------- */
+
+/**
+ * Link Invert
+ *
+ * For links used in dark areas of UI.
+ */
+.c-link--invert,
+.c-link-back--invert /* ⚠️ [SEE DEPRECATION WARNING] */ {
+  color: color(white);
 }

--- a/packages/sky-toolkit-ui/components/_modal.scss
+++ b/packages/sky-toolkit-ui/components/_modal.scss
@@ -2,6 +2,15 @@
    COMPONENTS / #MODAL
    ========================================================================== */
 
+/**
+ * ⚠️ DEPRECATION WARNING
+ * The following classes will be deprecated in sky-toolkit-ui@3.0.0, please use
+ * the alternatives detailed below:
+ *   ◦ `.c-modal__close-label` → `c-link__label`
+ *   ◦ `c-modal__close-icon` ⨯
+ *      No longer necessary, please use `c-link c-link--close` on the parent.
+ */
+
 // Imports
 @import "sky-toolkit-core/tools";
 
@@ -81,7 +90,7 @@
  * The button to close the Modal. This sits on the right side
  * of the Modal header.
  *
- * 1. Normalise the buttons spacing to visually mirror the overlay component.
+ * 1. Normalise the buttons spacing to visually mirror the modal component.
  */
 .c-modal__close {
   margin-top: $global-spacing-unit; /* [1] */
@@ -89,7 +98,7 @@
 }
 
 /**
- * Modal close button icon
+ * Modal close button icon - ⚠️ [SEE DEPRECATION WARNING]
  *
  * The icon for the close button. This sits to the right of
  * the text.
@@ -104,7 +113,7 @@
 }
 
 /**
- * Modal close button label
+ * Modal close button label - ⚠️ [SEE DEPRECATION WARNING]
  *
  * Sits to the left of the icon, hidden on smaller screens.
  */

--- a/packages/sky-toolkit-ui/components/_overlay.scss
+++ b/packages/sky-toolkit-ui/components/_overlay.scss
@@ -2,6 +2,15 @@
    COMPONENTS / #OVERLAY
    ========================================================================== */
 
+/**
+ * ⚠️ DEPRECATION WARNING
+ * The following classes will be deprecated in sky-toolkit-ui@3.0.0, please use
+ * the alternatives detailed below:
+ *   ◦ `.c-overlay__close-label` → `c-link__label`
+ *   ◦ `c-overlay__close-icon` ⨯
+ *      No longer necessary, please use `c-link c-link--close` on the parent.
+ */
+
 // Imports
 @import "sky-toolkit-core/tools";
 
@@ -103,7 +112,7 @@ $overlay-header-height-small: 60px;
 }
 
 /**
- * Overlay close button
+ * Overlay close button - ⚠️ [SEE DEPRECATION WARNING]
  *
  * The button to close the overlay. This usually sits at the right side of the
  * overlay header, but can be displayed to the left with the
@@ -118,7 +127,7 @@ $overlay-header-height-small: 60px;
 }
 
 /**
- * Hide the close button label on smaller devices
+ * Hide the close button label on smaller devices - ⚠️ [SEE DEPRECATION WARNING]
  */
 .c-overlay__close-label {
   vertical-align: middle;
@@ -142,7 +151,7 @@ $overlay-header-height-small: 60px;
     text-align: left;
   }
 
-  .c-overlay__close-icon {
+  .c-overlay__close-icon { /* ⚠️ [SEE DEPRECATION WARNING] */
     margin-left: 0;
     margin-right: $global-spacing-unit-small;
   }

--- a/packages/sky-toolkit-ui/components/_panel.scss
+++ b/packages/sky-toolkit-ui/components/_panel.scss
@@ -62,8 +62,8 @@ $panel-spacing: $global-spacing-unit * 3;
  *
  * Used for navigating backwards in a panel journey.
  *
- * This should be applied as a BEM Mix alongside `.c-link .c-link-back`.
- * e.g. `<button class="c-panel__back c-link c-link-back">Back</button>`
+ * This should be applied as a BEM Mix alongside `.c-link .c-link--back`.
+ * e.g. `<button class="c-panel__back c-link c-link--back">Back</button>`
  *
  * 1. Position the button in top left of panel
  * 2. Provide spacing for cross icon
@@ -78,27 +78,36 @@ $panel-spacing: $global-spacing-unit * 3;
  *
  * Used for closing the panel on completion of a journey.
  *
- * This should be applied as a BEM Mix alongside `.c-link`.
- * e.g. `<button class="c-panel__toggle c-link">Select</button>`
+ * This should be applied as a BEM Mix alongside `c-link c-link--close`.
+ * e.g. `<button class="c-panel__toggle c-link c-link--close">Close</button>`
  *
  * 1. Position the button in top right of panel
- * 2. Provide spacing for cross icon
- * 3. Inherit the font colour for light and dark panels.
- * 4. Offset cross icon to align with text
+ * 2. Inherit the font colour for light and dark panels.
  */
 .c-panel__toggle {
   right: $global-spacing-unit; /* [1] */
-  padding-right: $panel-icon-size; /* [2] */
-  color: inherit; /* [3] */
+  color: inherit; /* [2] */
 
-  &::after {
-    display: inline-block;
-    margin-left: $global-spacing-unit-tiny;
-    position: absolute;  /* [4] */
-    top: 50%; /* [4] */
-    transform: translateY(-50%); /* [4] */
-    content: "\2715"; // ×
-    font-size: 1.5em;
+  /**
+   * ⚠️ DEPRECATION WARNING
+   * The following styles will be deprecated in sky-toolkit-ui@3.0.0, please use
+   * `c-panel__toggle c-link c-link--close` instead.
+   * To avoid clashing with the new approach (specifically, to avoid weird
+   * behaviour in IE where `font-size` cascades and multiplies) we need to
+   * wrap our previously-surfaced styles in a `:not` selector.
+   */
+  &:not(.c-link--close) {
+    padding-right: $panel-icon-size;
+
+    &::after {
+      display: inline-block;
+      margin-left: $global-spacing-unit-tiny;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      content: "\2715"; // ×
+      font-size: 1.5em;
+    }
   }
 }
 
@@ -119,8 +128,8 @@ $panel-spacing: $global-spacing-unit * 3;
 /**
  * Dark-themed panels
  *
- * Note: For `.c-link-back` you will need to apply an additional class of
- *       `.c-link-back--invert` to achieve darker-themed styling.
+ * Note: For `.c-link--back` you will need to apply an additional class of
+ *       `.c-link--invert` to achieve darker-themed styling.
  */
 .c-panel--dark {
   background-color: $panel-background-color-dark;

--- a/packages/sky-toolkit-ui/docs/components/links.md
+++ b/packages/sky-toolkit-ui/docs/components/links.md
@@ -36,32 +36,56 @@ and external link styles on buttons.
 <button class="c-link">This is a Button styled as a link</button>
 ```
 
+### Label
+
+For some use cases on smaller screens you may want to hide the Link's label
+whilst keeping the icon visible.
+
+```html
+<button class="c-link c-link--close"><span class="c-link__label">Close</span></button>
+```
+
 ---
 
-## Back
+## Modifiers
+
+### Icons
+
+#### Back
 
 The `.c-link-back` class from `sky-toolkit-ui` utilises the same default
 link styling, with an additional backward-facing chevron indicator.
 
 ```html
-<a href="#" class="c-link-back">This is a back link</a>
+<a href="#" class="c-link c-link--back">This is a back link</a>
 ```
 
-### Back (Invert)
+#### Close
 
-We use this inverted back link when placed over darker backgrounds.
+The `.c-link--close` class from `sky-toolkit-ui` utilises the same default
+link behaviour with its own colour and additional icon indicator.
 
-```html { "theme": "dark" }
-<a href="#" class="c-link-back c-link-back--invert">This is a back link</a>
+```html
+<a href="#" class="c-link c-link--close">Close</a>
 ```
 
----
-
-## External
+#### External
 
 The `.c-link-external` class from `sky-toolkit-ui` utilises the same default
 link styling, with an additional chevron indicator.
 
 ```html
-<a href="#" class="c-link-external">This is an external link</a>
+<a href="#" class="c-link c-link--external">This is an external link</a>
+```
+
+### Cosmetic
+
+### Invert
+
+We use this inverted close link when placed over darker backgrounds.
+
+```html { "theme": "dark" }
+<a href="#" class="c-link c-link--back c-link--invert">Back</a>
+<br/>
+<a href="#" class="c-link c-link--close c-link--invert">Close</a>
 ```

--- a/packages/sky-toolkit-ui/docs/components/modal.md
+++ b/packages/sky-toolkit-ui/docs/components/modal.md
@@ -20,10 +20,8 @@ By default, the Modal component is centered to the middle of the viewport, wrapp
 <aside class="c-modal-cover" role="dialog" aria-label="A label describing the Modal's current content" tabIndex="-1">
   <div class="c-modal">
     <div class="u-text-right">
-      <button class="c-link-faux c-modal__close" aria-label="Close Modal">
-        <span class="c-modal__close-label">Close</span>
-        <!-- `img` for demo purposes, please use `svg` in production -->
-        <img class="c-modal__close-icon" src="https://www.sky.com/assets/toolkit/docs/overlay/close.svg" alt="" />
+      <button class="c-modal__close c-link c-link--close" aria-label="Close Modal">
+        Close
       </button>
     </div>
     <div class="c-modal__body">

--- a/packages/sky-toolkit-ui/docs/components/overlay.md
+++ b/packages/sky-toolkit-ui/docs/components/overlay.md
@@ -34,10 +34,8 @@ button.
 ```html { "container": [ "overlay", "flush" ] }
 <article class="c-overlay">
   <header class="c-overlay__header">
-    <button class="c-overlay__close c-link-faux u-vertical-align-center">
-      <span class="c-overlay__close-label">Close</span>
-      <!-- `img` for demo purposes, please use `svg` in production -->
-      <img class="c-overlay__close-icon" src="https://www.sky.com/assets/toolkit/docs/overlay/close.svg" alt="" />
+    <button class="c-overlay__close c-link c-link--close u-vertical-align-center">
+      Close
     </button>
   </header>
   <div class="c-overlay__content">
@@ -60,10 +58,8 @@ rendered in the right side of the header, such as a basket or continue button.
 ```html { "container": [ "overlay", "flush" ] }
 <article class="c-overlay c-overlay--close-left">
   <header class="c-overlay__header">
-    <button class="c-overlay__close c-link-faux u-vertical-align-center">
-      <span class="c-overlay__close-label">Close</span>
-      <!-- `img` for demo purposes, please use `svg` in production -->
-      <img class="c-overlay__close-icon" src="https://www.sky.com/assets/toolkit/docs/overlay/close.svg" alt="" />
+    <button class="c-overlay__close c-link c-link--close u-vertical-align-center">
+      Close
     </button>
   </header>
   <div class="c-overlay__content">
@@ -77,16 +73,17 @@ rendered in the right side of the header, such as a basket or continue button.
 
 ## Hiding the Close Label
 
-There are some use cases where you would want to show the close button, but
-without the label.
+For some use cases on smaller screens you may want to hide the close button's 
+label whilst keeping the icon visible.
+
+To do so, utilise `.c-link__label` from
+[sky-toolkit-ui/components/links](links.md).
 
 ```html { "container": [ "overlay", "flush" ] }
 <article class="c-overlay">
   <header class="c-overlay__header">
-    <button class="c-overlay__close c-link-faux u-vertical-align-center">
-      <span class="c-overlay__close-label u-hide-visually">Close</span>
-      <!-- `img` for demo purposes, please use `svg` in production -->
-      <img class="c-overlay__close-icon" src="https://www.sky.com/assets/toolkit/docs/overlay/close.svg" alt="" />
+    <button class="c-overlay__close c-link c-link--close u-vertical-align-center">
+      <span class="c-link__label">Close</span>
     </button>
   </header>
   <div class="c-overlay__content">

--- a/packages/sky-toolkit-ui/docs/components/panel.md
+++ b/packages/sky-toolkit-ui/docs/components/panel.md
@@ -30,7 +30,7 @@ the content inside a wrapper with a class of `.o-container`.
 <article class="c-panel is-open">
   <div class="c-panel__content">
     <button class="c-panel__back c-link c-link-back">Back</button>
-    <button class="c-panel__toggle c-link">Close</button>
+    <button class="c-panel__toggle c-link c-link--close">Close</button>
     <div class="o-container">
       <h2 class="c-heading-bravo">This is a title</h2>
       <p class="c-text-body u-text-constrain">
@@ -56,7 +56,7 @@ A dark version of the panel with a black background and white text.
 <article class="c-panel c-panel--dark is-open">
   <div class="c-panel__content">
     <button class="c-panel__back c-link c-link-back c-link-back--invert">Back</button>
-    <button class="c-panel__toggle c-link">Close</button>
+    <button class="c-panel__toggle c-link c-link--close c-link--invert">Close</button>
     <div class="o-container">
       <h2 class="c-heading-bravo">This is a title</h2>
       <p class="c-text-body u-text-constrain">


### PR DESCRIPTION
## Description

Whilst looking at https://github.com/sky-uk/toolkit/issues/442 I realised it would make more sense to introduce a new "Close Link" component for consistent `Close ×` buttons.

As it's ideal to mark this up as a `<button>` for the majority of use-cases (whilst maintaining "Link" behaviour/cosmetics) we want to borrow some of the styling from `.c-link` - which "resets" `<button>`s to an `<a>` appearance. Surely it makes sense to do the same for our other Link components? (External/Back)

What I propose is that we gracefully deprecate the existing blocks into modifiers (as per the inline docs I've written) and deprecate at 3.0 (which I will raise a separate ticket for if accepted).

### Issue (after merge)

The following issue will be raised after merge:

> #### Breaking changes to Link
>
>**Is your feature request related to a problem? Please describe.**
>Now that `c-link--close` is in effect and new modifier classes have been added, we can make the breaking changes in `sky-toolkit@3.0.0`.
>
>**Describe the solution you'd like**
> - [ ] Remove `.c-link-external` in favour of `.c-link--external`
> - [ ] Remove `.c-link-back` in favour of `.c-link--back`
> - [ ] Remove `.c-link-back--invert` in favour of `.c-link--back c-link--invert`
> - [ ] Remove icon from`.c-panel__toggle` in favour of `.c-link--close`
> - [ ] Remove `.c-modal__close-icon`
> - [ ] Remove `.c-overlay__close-icon` (plus modifications by `c-overlay--close-left`)
> - [ ] Remove `.c-overlay__close-label` in favour of `.c-link__label`
>
>**Describe alternatives you've considered**
>Mixins (but this gets super messy) 
>
>**Additional context**
>Alignment of close buttons across Toolkit

## Related Issue

#442 

## Motivation and Context

Trying to add Modals/Overlays to sky.com/toolkit and this is kind of a blocker due to conflicts in the internal platform 😢 

## How Has This Been Tested?

Existing tests pass, browser testing to be conducted.

## Markup

```html
<button class="c-link">
  I look like a link but I'm a button 😶
</button>
<button class="c-link c-link--external">
  External
</button>
<button class="c-link c-link--back">
  Back
</button>
<button class="c-link c-link--close">
  Close
</button>
```

## Screenshots

### Link

![screen shot 2018-07-04 at 09 19 49](https://user-images.githubusercontent.com/7349341/42265588-dea8b318-7f6b-11e8-845e-c1d747605e8b.png)

### Modal

![screen shot 2018-07-04 at 09 20 12](https://user-images.githubusercontent.com/7349341/42265589-e07d9b72-7f6b-11e8-953c-99deaddb4afb.png)

### Overlay

![screen shot 2018-07-04 at 09 20 30](https://user-images.githubusercontent.com/7349341/42265616-f3552670-7f6b-11e8-9227-70cfc5ef676c.png)
![screen shot 2018-07-04 at 09 20 42](https://user-images.githubusercontent.com/7349341/42265620-f4b500da-7f6b-11e8-9b33-53b8bf64f1e2.png)
![screen shot 2018-07-04 at 09 21 00](https://user-images.githubusercontent.com/7349341/42265624-f5d89120-7f6b-11e8-9b44-f4a9e95cbb3f.png)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [x] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome
- [x] Edge (position slightly off center)
- [x] Firefox (slightly smaller icon for "close")
- [x] IE9 - Bugs fixed via `:not()`
- [x] IE10 - Bugs fixed via `:not()`
- [x] IE11 - Bugs fixed via `:not()`
- [x] Opera
- [x] Safari
- [x] Mobile Devices
  - [x] iOS - Chrome / Safari (Doesn't look like Sky Text cross 🤷‍♂️ )
  - [x] Android 
- [x] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.

---

Whilst working on this, I also noticed another issue on the rendering of the multiplication glyph (https://github.com/sky-uk/toolkit/issues/444)
