### PR TITLE
[refs #451] Update page gradient

### DIFF
--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -14,12 +14,12 @@ $gradients: (
     100%: #fff
   ),
   page: (
-    0%:   #c9c7d1,
-    6%:   #e5e5ea,
-    20%:  #fefefe,
-    80%:  #fefefe,
+    0%:   #e4e3e8,
+    6%:   #f2f2f5,
+    20%:  #fff,
+    80%:  #fff,
     94%:  #e5e5ea,
-    100%: #c9c7d1
+    100%: #e4e3e8
   ),
   page-small: (
     0%:   #f2f2f5,


### PR DESCRIPTION
As per a design request, the page gradient we use on the background of every page has been updated. Its effectively a 50% reduction on the grey

## Related Issue
https://github.com/sky-uk/toolkit/issues/451

## Motivation and Context
Design alignment

## How Has This Been Tested?
Ran the changes through the preview app.

## Markup
<!-- If appropriate, please provide markup to compliment your changes. -->


## Screenshots
Before:
![screen shot 2018-08-10 at 09 05 07](https://user-images.githubusercontent.com/14904083/43949122-83082134-9c84-11e8-9d35-6f0a9ea68d76.png)

After:
![screen shot 2018-08-10 at 09 04 46](https://user-images.githubusercontent.com/14904083/43949105-7c276fc8-9c84-11e8-8864-63a391583364.png)

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [ ] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome
- [x] Edge
- [x] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
