### PR TITLE
[refs #tkt-456] Add huge spacing

### DIFF
--- a/packages/sky-toolkit-core/docs/settings/globals.md
+++ b/packages/sky-toolkit-core/docs/settings/globals.md
@@ -23,6 +23,7 @@ Exposed in [sky-toolkit-core/utilities/spacing](../../utilities/_spacing.scss).
 | `$global-spacing-unit-tiny`    | ¼ Default     |
 | `$global-spacing-unit-small`   | ½ Default     |
 | `$global-spacing-unit-large`   | 2 × Default   |
+| `$global-spacing-unit-x-large` | 4 × Default   |
 
 ---
 
@@ -73,7 +74,7 @@ Exposed in [sky-toolkit-core/utilities/widths](../../utilities/_widths.scss).
 | `$global-shadow-intensity`     | Default       |
 | `$global-shadow-x`             | Default       |
 | `$global-shadow-y`             | Default       |
-| `$global-shadow-blur`          | Default       | 
+| `$global-shadow-blur`          | Default       |
 | `$global-shadow-spread`        | Default       |
 | `$global-shadow`               | All of above  |
 | `$global-text-shadow`          | All of above  |

--- a/packages/sky-toolkit-core/docs/utilities/spacing.md
+++ b/packages/sky-toolkit-core/docs/utilities/spacing.md
@@ -12,7 +12,7 @@ related:
 
 # Spacing
 
-Each of the spacing units defined in 
+Each of the spacing units defined in
 [sky-toolkit-core/settings/globals](../settings/globals.md) are available as
 `u-margin` and `u-padding` utility classes. Each of these can be applied on:
 
@@ -24,13 +24,14 @@ Each of the spacing units defined in
 
 With the following size suffixes:
 
-| Suffix              | Size                         |
-|---------------------|------------------------------|
-| No suffix (Default) | `$global-spacing-unit`       |
-| `-none`             | `0`                          |
-| `-tiny`             | `$global-spacing-unit-tiny`  |
-| `-small`            | `$global-spacing-unit-small` |
-| `-large`            | `$global-spacing-unit-large` |
+| Suffix              | Size                            |
+|---------------------|---------------------------------|
+| No suffix (Default) | `$global-spacing-unit`          |
+| `-none`             | `0`                             |
+| `-tiny`             | `$global-spacing-unit-tiny`     |
+| `-small`            | `$global-spacing-unit-small`    |
+| `-large`            | `$global-spacing-unit-large`    |
+| `-x-large`          | `$global-spacing-unit-x-large`  |
 
 ## Margin
 
@@ -42,6 +43,7 @@ Applies spacing to the **outside** of the box-model.
 <div class="u-margin-all-small">Small Margin</div>
 <div class="u-margin-all">Default Margin</div>
 <div class="u-margin-all-large">Large Margin</div>
+<div class="u-margin-all-x-large">Extra Large Margin</div>
 
 <hr class="c-keyline"/>
 
@@ -50,6 +52,7 @@ Applies spacing to the **outside** of the box-model.
 <div class="u-margin-left-small">Small Left Margin</div>
 <div class="u-margin-right">Default Right Margin</div>
 <div class="u-margin-bottom-large">Large Bottom Margin</div>
+<div class="u-margin-bottom-x-large">Extra Large Bottom Margin</div>
 ```
 
 ---
@@ -64,6 +67,7 @@ Applies spacing to the **inside** of the box-model.
 <div class="u-padding-all-small">Small Padding</div>
 <div class="u-padding-all">Default Padding</div>
 <div class="u-padding-all-large">Large Padding</div>
+<div class="u-padding-all-x-large">Extra Large Padding</div>
 
 <hr class="c-keyline"/>
 
@@ -72,4 +76,5 @@ Applies spacing to the **inside** of the box-model.
 <div class="u-padding-left-small">Small Left Padding</div>
 <div class="u-padding-right">Default Right Padding</div>
 <div class="u-padding-bottom-large">Large Bottom Padding</div>
+<div class="u-padding-bottom-x-large">Extra Large Bottom Padding</div>
 ```

--- a/packages/sky-toolkit-core/settings/_globals.scss
+++ b/packages/sky-toolkit-core/settings/_globals.scss
@@ -16,7 +16,7 @@ $global-spacing-unit: 20px !default;
 $global-spacing-unit-tiny: round(0.25 * $global-spacing-unit);
 $global-spacing-unit-small: round(0.5 * $global-spacing-unit);
 $global-spacing-unit-large: round(2 * $global-spacing-unit);
-$global-spacing-unit-ludicrous: round(4 * $global-spacing-unit);
+$global-spacing-unit-x-large: round(4 * $global-spacing-unit);
 
 // Global Container Settings
 // ==============================================

--- a/packages/sky-toolkit-core/settings/_globals.scss
+++ b/packages/sky-toolkit-core/settings/_globals.scss
@@ -16,6 +16,7 @@ $global-spacing-unit: 20px !default;
 $global-spacing-unit-tiny: round(0.25 * $global-spacing-unit);
 $global-spacing-unit-small: round(0.5 * $global-spacing-unit);
 $global-spacing-unit-large: round(2 * $global-spacing-unit);
+$global-spacing-unit-ludicrous: round(4 * $global-spacing-unit);
 
 // Global Container Settings
 // ==============================================

--- a/packages/sky-toolkit-core/utilities/_spacing.scss
+++ b/packages/sky-toolkit-core/utilities/_spacing.scss
@@ -36,6 +36,7 @@ $global-spacing-sizes: (
   -tiny: $global-spacing-unit-tiny,
   -small: $global-spacing-unit-small,
   -large: $global-spacing-unit-large,
+  -ludicrous: $global-spacing-unit-ludicrous,
   -none: 0,
 ) !default;
 

--- a/packages/sky-toolkit-core/utilities/_spacing.scss
+++ b/packages/sky-toolkit-core/utilities/_spacing.scss
@@ -36,7 +36,7 @@ $global-spacing-sizes: (
   -tiny: $global-spacing-unit-tiny,
   -small: $global-spacing-unit-small,
   -large: $global-spacing-unit-large,
-  -ludicrous: $global-spacing-unit-ludicrous,
+  -x-large: $global-spacing-unit-x-large,
   -none: 0,
 ) !default;
 


### PR DESCRIPTION
![](https://media0.giphy.com/media/96byjouCVtGF2/giphy.gif)

Adds new huge spacing utility to add 80px paddings and margins.

## Description
Adds larger `80px` spacing unit. 

## Related Issue
https://github.com/sky-uk/toolkit/issues/456

## Motivation and Context
This helps remove a good chunk of custom margins/padding used in multiple apps for spacing out content.

## How Has This Been Tested?
Tested output CSS and tried in the preview environment

## Markup
```
<section class="u-margin-y-huge"></section>
```

## Screenshots
<!-- If appropriate, please provide screenshots. -->


## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [ ] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [x] New functions and mixins have appropriate tests.
- [x] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
