### PR TITLE
[refs #452] Remove transform from gradient-text mixin

### DIFF
--- a/packages/sky-toolkit-core/test/functional/tools/_gradients.scss
+++ b/packages/sky-toolkit-core/test/functional/tools/_gradients.scss
@@ -159,7 +159,6 @@ $test-module-area: "Tools / Gradients /";
       @include contains() {
         -webkit-background-clip: text;
         -webkit-text-fill-color: transparent;
-        -webkit-transform: translate3d(0, 0, 0);
         display: inline-block;
         color: #079ef8;
         background-image: -webkit-linear-gradient(left, #0080df 0%, #079ef8 100%);
@@ -177,7 +176,6 @@ $test-module-area: "Tools / Gradients /";
       @include contains() {
         -webkit-background-clip: text;
         -webkit-text-fill-color: transparent;
-        -webkit-transform: translate3d(0, 0, 0);
         display: inline-block;
         color: #0073c5;
         background-image: -webkit-radial-gradient(center, ellipse cover, #079ef8 0%, #0080df 100%);

--- a/packages/sky-toolkit-core/tools/_gradients.scss
+++ b/packages/sky-toolkit-core/tools/_gradients.scss
@@ -208,7 +208,6 @@
       // Vendor prefix required as other browsers lack support.
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
-      -webkit-transform: translate3d(0, 0, 0);
       // Ensure that the gradient finishes flush with the text and not with the
       // element’s natural bounding box.
       display: inline-block;


### PR DESCRIPTION
## Description
Chrome v69 causes gradients created by our gradient-text mixin to not display properly - making text transparent. Removing `-webkit-transform: translate3d(0, 0, 0);` from the `gradient-text` mixin prevents this happening.


## Related Issue
https://github.com/sky-uk/toolkit/issues/452


## Motivation and Context
This change is required to fix an issue in the next version of Chrome (69) which is due for release on Sep 4 2018.


## How Has This Been Tested?
This has been tested locally in Chrome 69.


## Screenshots
![screen shot 2018-08-13 at 16 07 25](https://user-images.githubusercontent.com/3612060/44040392-084a1d44-9f13-11e8-8344-3dbfdfad7ca1.png)
🤢 


## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [x] Bug Fix *(non-breaking change which fixes an issue)*
- [ ] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome
- [ ] Edge
- [x] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [x] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)