### PR TITLE
Fix intermittent faint strikethrough rendering on IE11/Edge

### DIFF
--- a/packages/sky-toolkit-ui/components/_price.scss
+++ b/packages/sky-toolkit-ui/components/_price.scss
@@ -44,12 +44,17 @@ $price-footnote-spacing: $global-spacing-unit-tiny;
  */
 .c-price--strike {
   position: relative;
-  text-decoration: none;  /* [1] */
+  text-decoration: none; /* [1] */
 
   /**
    * Striked Pricing: Pseudo Strike
    *
    * Renders a diagonal line through the text from bottom left to top right
+   *
+   * 1. Fix IE11 and Edge rendering very faint strikethrough depending on the
+   *    vertical position of the price in the viewport. 1.4px is enough to
+   *    fix the issue without changing the rendering of the strikethrough
+   *    on other browsers.
    */
   &::after {
     /*! autoprefixer: off */
@@ -59,7 +64,7 @@ $price-footnote-spacing: $global-spacing-unit-tiny;
     left: 0;
     top: 50%;
     right: 0;
-    border-top: 1px solid;
+    border-top: 1.4px solid; /* [1] */
     -ms-transform: rotate(-10deg);
     transform: rotate(-10deg);
   }


### PR DESCRIPTION
## Description
[Price]: Fix intermittent faint strikethrough rendering on IE11/Edge

## Related Issue
Toolkit: #460 
One Shop: https://cbsjira.bskyb.com/browse/ONLTRANS-531


## Motivation and Context
As mentioned in the patch, the border width increase does not change the rendering of the strike in Win/Mac versions of Chrome or Firefox, nor in desktop Safari or iOS Safari (bumping to 1.5, however,_does_ result in a noticeable thickening, because browsers round this up to 2px), but is enough to kick IE/Edge into rendering a visible 1px line all of the time. The downside to this approach is that it doesn't seem like the rendering of fractional pixel widths for borders is defined in the CSS spec, so future versions of browsers could potentially render this differently.

## How Has This Been Tested?
Rendered the below static HTML page in the browsers mentioned above.

## Markup
```html
<span class="c-price-container" data-test-id="toolkit-price" data-example="some-data-attributes"
      aria-label="previous price"><s class="some-css-class c-price c-price--strike c-price--fraction"><span class="c-price__main">£5</span><span
          class="c-price__fractional">.95</span></s></span>
```

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [x] Bug Fix *(non-breaking change which fixes an issue)*
- [ ] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome (tested macOs and Windows)
- [x] Edge
- [x] Firefox (tested macOs and Windows)
- [ ] IE9
- [ ] IE10
- [x] IE11
- [x] Opera (tested macOs only)
- [x] Safari
- [x] Mobile Devices (tested iOS Safari 11.2, Android 7.1.1 Chrome)
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [x] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [x] I have added instructions on how to test my changes.
