### PR TITLE
[refs #460] Use straight strikethrough for IE11/Edge to avoid intermittent faint rendering

### DIFF
--- a/packages/sky-toolkit-core/docs/tools/mixins.md
+++ b/packages/sky-toolkit-core/docs/tools/mixins.md
@@ -220,3 +220,18 @@ mixin helps us to set a common height on elements based on our [`text-body`'s
   @include height-sizing(fixed);
 }
 ```
+
+## Browser Hack
+Allows defining rulesets specific to particular browser(s). Set the browser
+versions to target by name. Currently supported:
+
+- ie11
+- edge
+
+```scss { "render": false }
+.foo {
+  @include browser-hack(ie11, edge) {
+    background: pink;
+  }
+}
+```

--- a/packages/sky-toolkit-core/tools/_mixins.scss
+++ b/packages/sky-toolkit-core/tools/_mixins.scss
@@ -205,3 +205,24 @@
     @warn "`#{$height}` is not a valid option. Height can only be `fixed` or `padding`-based.";
   }
 }
+
+// @include browser-hack()
+// ==============================================
+//  Sources for hacks:
+// - IE11: https://stackoverflow.com/questions/20541306/how-to-write-a-css-hack-for-ie-11#22085269
+// - Edge: https://stackoverflow.com/questions/32201586/how-to-identify-microsoft-edge-browser-via-css#32202953
+@mixin browser-hack($browser...) {
+  @each $version in $browser {
+    @if $version == ie11 {
+      @at-root _:-ms-fullscreen, :root & {
+        @content;
+      }
+    } @else if $version == edge {
+      @supports (-ms-ime-align: auto) {
+        @content;
+      }
+    } @else {
+      @warn "#{browser} is not a valid option. $browser can be one of 'ie11' or 'edge'";
+    }
+  }
+}

--- a/packages/sky-toolkit-ui/components/_price.scss
+++ b/packages/sky-toolkit-ui/components/_price.scss
@@ -46,6 +46,10 @@ $price-footnote-spacing: $global-spacing-unit-tiny;
   position: relative;
   text-decoration: none;  /* [1] */
 
+  @include browser-hack(ie11, edge) {
+    text-decoration: line-through;
+  }
+
   /**
    * Striked Pricing: Pseudo Strike
    *
@@ -62,6 +66,10 @@ $price-footnote-spacing: $global-spacing-unit-tiny;
     border-top: 1px solid;
     -ms-transform: rotate(-10deg);
     transform: rotate(-10deg);
+
+    @include browser-hack(ie11, edge) {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
**Related ticket**
Toolkit: #460
One Shop: https://cbsjira.bskyb.com/browse/ONLTRANS-531

Second solution for #460. This one uses CSS hacks to target IE11 and Edge - see #461 for alternative which preserves the diagonal strike for IE/Edge.

**Screenshot**
<img width="145" alt="screen shot 2018-09-20 at 11 30 04" src="https://user-images.githubusercontent.com/30408139/45812737-8ecbc480-bcc8-11e8-9d67-18451426fcaa.png">
