### PR TITLE
Commitizen and Commitlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ A combination of compiled and Sass implementation:
       <link rel="stylesheet" href="main.css">
       ```
 
-2. Follow the [Sass Imports](#sass-imports) steps defined below, making sure you 
+2. Follow the [Sass Imports](#sass-imports) steps defined below, making sure you
    import `sky-toolkit-core/tools`, **not** `/all`.
 
 ### Sass Imports
@@ -170,11 +170,11 @@ A combination of compiled and Sass implementation:
       /* main.scss (compiles to main.css) */
       @import "sky-toolkit-core/tools";
       ```
-      
+
       This is required if you're extending any Toolkit styles or creating
       custom components.
 
-    * If you're **not** following the Hybrid method above and you're using 
+    * If you're **not** following the Hybrid method above and you're using
       Toolkit fully via Sass, you **must** use **`/all`** to output the core.
 
       ```css

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/config/commit/config.js
+++ b/config/commit/config.js
@@ -37,6 +37,15 @@ module.exports = {
       name: 'Revert - Reverts a previous commit',
     },
   ],
+  messages: {
+    type: 'What kind of change did you make?',
+    scope: 'Which category does the change most relate to?',
+    subject: 'Complete the sentence "This Commit will...',
+    body: 'Give context with some extra background info (optional)\n',
+    breaking: 'List any BREAKING CHANGES (optional):\n',
+    footer: 'Which issue does this relate to? e.g. #469',
+    confirmCommit: 'Are you sure you want to proceed with the commit above?',
+  },
   scopes: [
     {
       name: 'core',
@@ -55,4 +64,5 @@ module.exports = {
     },
   ],
   allowBreakingChanges: ['feat', 'fix', 'refactor'],
+  footerPrefix: 'Closes:',
 };

--- a/config/commit/config.js
+++ b/config/commit/config.js
@@ -1,0 +1,58 @@
+module.exports = {
+  types: [
+    {
+      value: 'feat',
+      name: 'Feature - A new feature for End Users',
+    },
+    {
+      value: 'fix',
+      name: 'Fix - A bug fix affecting End Users',
+    },
+    {
+      value: 'test',
+      name: 'Test - adding missing tests or correcting existing tests',
+    },
+    {
+      value: 'build',
+      name: 'Build - Changes to build/release/lint/test/editor scripts or other local developer tooling',
+    },
+    {
+      value: 'style',
+      name: 'Style - Changes to whitespace, formatting, lint fixes, missing semicolons, etc',
+    },
+    {
+      value: 'refactor',
+      name: 'Refactor - An improvement to the design of existing code without changing its external behavior',
+    },
+    {
+      value: 'docs',
+      name: 'Docs - Changes to Markdown or other Documentation',
+    },
+    {
+      value: 'chore',
+      name: 'Chore - Other housekeeping changes that do not modify src or test files',
+    },
+    {
+      value: 'revert',
+      name: 'Revert - Reverts a previous commit',
+    },
+  ],
+  scopes: [
+    {
+      name: 'core',
+    },
+    {
+      name: 'docs',
+    },
+    {
+      name: 'toolkit-ui',
+    },
+    {
+      name: 'toolkit-core',
+    },
+    {
+      name: 'preview',
+    },
+  ],
+  allowBreakingChanges: ['feat', 'fix', 'refactor'],
+};

--- a/lerna.json
+++ b/lerna.json
@@ -1,11 +1,14 @@
 {
-  "lerna": "2.0.0-rc.5",
   "packages": [
     "packages/*"
   ],
   "version": "2.29.0",
   "command": {
+    "init": {
+      "exact": true
+    },
     "publish": {
+      "conventionalCommits": true,
       "exact": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,22 @@
   },
   "config": {
     "paths": "--include-path node_modules/ --include-path packages/sky-toolkit-core/node_modules/ --include-path packages/sky-toolkit-ui/node_modules/",
-    "precision": "--precision 9"
+    "precision": "--precision 9",
+    "commitizen": {
+      "path": "node_modules/cz-customizable"
+    },
+    "cz-customizable": {
+      "config": "config/commit/config.js"
+    }
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
   },
   "scripts": {
     "clean": "touch build/tmp.css && rm build/*.css",
+    "commit": "git-cz",
     "nuke": "npm run clean && rm -rf node_modules/ && lerna clean",
     "watch": "node-sass $npm_package_config_precision --output-style expanded -w $npm_package_config_paths build.scss build/toolkit.css",
     "lint": "npm run lint:scss && npm run lint:js",
@@ -32,6 +44,8 @@
     "node_modules/"
   ],
   "devDependencies": {
+    "@commitlint/cli": "7.2.1",
+    "@commitlint/config-conventional": "7.1.2",
     "@sky-uk/eslint-config-sky": "22.0.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "8.2.2",
@@ -41,8 +55,10 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "cheerio": "^1.0.0-rc.2",
+    "commitizen": "3.0.4",
     "css-hot-loader": "^1.3.8",
     "css-loader": "^0.28.10",
+    "cz-customizable": "5.3.0",
     "eslint": "4.18.2",
     "eslint-plugin-import": "2.9.0",
     "eslint-plugin-mocha": "4.12.1",
@@ -50,7 +66,8 @@
     "eslint-plugin-promise": "3.7.0",
     "extract-text-webpack-plugin": "^3.0.2",
     "eyeglass": "^1.3.0",
-    "lerna": "^2.4.0",
+    "husky": "1.2.0",
+    "lerna": "3.4.3",
     "mocha": "^4.0.1",
     "node-sass": "^4.7.2",
     "pre-commit": "^1.2.2",

--- a/packages/sky-toolkit-core/package.json
+++ b/packages/sky-toolkit-core/package.json
@@ -22,6 +22,5 @@
     "eyeglass": "^1.3.0",
     "mocha": "^4.0.1",
     "sass-true": "3.1.0"
-  },
-  "gitHead": "4f36a97d4ef238505b7beb977677ae9a10e72508"
+  }
 }

--- a/packages/sky-toolkit-ui/package.json
+++ b/packages/sky-toolkit-ui/package.json
@@ -19,6 +19,5 @@
     "eyeglass": "^1.3.0",
     "mocha": "^4.0.1",
     "sass-true": "3.1.0"
-  },
-  "gitHead": "4f36a97d4ef238505b7beb977677ae9a10e72508"
+  }
 }

--- a/packages/sky-toolkit/package.json
+++ b/packages/sky-toolkit/package.json
@@ -13,6 +13,5 @@
   "dependencies": {
     "sky-toolkit-core": "2.29.0",
     "sky-toolkit-ui": "2.29.0"
-  },
-  "gitHead": "4f36a97d4ef238505b7beb977677ae9a10e72508"
+  }
 }


### PR DESCRIPTION
## Description
This PR will make Toolkit a `Commitizen` friendly project. What does this mean for toolkit? Well it means we are going to start adopting a new commit style. 

This new commit style will effectively be identical to the one seen within pages-lib and is very much based around: https://github.com/commitizen/cz-conventional-changelog. This should mean that we add more clarity to our commits about what they are for, where they are being implemented and obviously the change they make.

Alonside this I have also added commitlint in to make sure that we all the sections we need for each commit are present.

This can all be kicked of using `yarn commit`

Example commit:
![commitizen](https://user-images.githubusercontent.com/14904083/48852644-b95bfb80-eda5-11e8-8471-af52f7b7b05f.gif)

## Related Issue
https://github.com/sky-uk/toolkit/issues/469

## Motivation and Context
Its time we started at looking to refine how we do things and start to align with Pages-Lib

## How Has This Been Tested?
All commits on this PR have been done using the new `yarn commit` command.

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [ ] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

