### PR TITLE
refactor(toolkit-ui): add abbr element styling reset

### DIFF
--- a/packages/sky-toolkit-core/elements/_typography.scss
+++ b/packages/sky-toolkit-core/elements/_typography.scss
@@ -27,3 +27,10 @@ h1, h2, h3, h4, h5, h6 {
 small {
   font: inherit;
 }
+
+/**
+ * Remove underline for abbr element.
+ */
+abbr[title] {
+  text-decoration: none;
+}


### PR DESCRIPTION
Closes: #476

## Description
Removes the default dotted underline styling on `<abbr>` elements. This lets us more easily use them for accessibility improvements without conflicting with design. 


## Related Issue
https://github.com/sky-uk/toolkit/issues/476


## Motivation and Context
This lets us make better use of the `<abbr>` element to provide a more meaningful experience for screen readers.


## How Has This Been Tested?
<!--
  Please describe in detail how you tested your changes.

  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->


## Markup
<!-- If appropriate, please provide markup to compliment your changes. -->
n/a

## Screenshots
<!-- If appropriate, please provide screenshots. -->
n/a

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [ ] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [x] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
