### PR TITLE
fix(toolkit-core): moving trim mixin to tools

### DIFF
--- a/packages/sky-toolkit-core/docs/tools/trim.md
+++ b/packages/sky-toolkit-core/docs/tools/trim.md
@@ -1,0 +1,12 @@
+---
+title: Trim
+source: sky-toolkit-core/tools/trim
+dependencies:
+  - sky-toolkit-core
+layout: component
+---
+
+# Trim
+
+See [sky-toolkit-ui/components/panel
+](../../../sky-toolkit-ui/docs/components/trim.md).

--- a/packages/sky-toolkit-core/tools/_all.scss
+++ b/packages/sky-toolkit-core/tools/_all.scss
@@ -14,3 +14,4 @@
 @import "gradients";
 @import "divider";
 @import "panels";
+@import "trim";

--- a/packages/sky-toolkit-core/tools/_trim.scss
+++ b/packages/sky-toolkit-core/tools/_trim.scss
@@ -1,0 +1,47 @@
+// =============================================================================
+// TOOLS / #TRIM
+// =============================================================================
+
+// @include trim-brands()
+// ==============================================
+
+// Generate branded trim by passing maps containing gradient values
+//
+// $custom: name of bespoke gradient map
+// $gradient-groups: names of prexisting gradient groups
+// see core/settings/gradients
+//
+// Example:
+// $my-custom-gradients: (
+//   cool-brand: (
+//     0%: purple,
+//     100%: hotpink
+//   )
+// );
+// .c-my-widget {
+//   @include trim-brands($my-custom-gradients, $tv-gradients);
+// }
+//
+// Generates:
+// .c-my-widget--cool-brand .c-trim {
+//   background-image: linear-grad ient(to right, #purple 0%, #hotpink 100%);
+// }
+// .c-my-widget--tv-master .c-trim {
+// ...
+
+@mixin trim-brands($custom, $gradient-groups...) {
+
+  // Add any custom gradients to the gloabl $gradients map
+  $gradients: map-merge($gradients, $custom) !global;
+
+  // Merge all the maps into one master map
+  $grouped-maps: multi-map-merge($custom, $gradient-groups...);
+
+  // Interate though the master map to generate modifers with the
+  // appropriate gradient values
+  @each $gradient in map-keys($grouped-maps) {
+    &--#{$gradient} .c-trim {
+      @include gradient-background($gradient, horizontal);
+    }
+  }
+}

--- a/packages/sky-toolkit-ui/components/_trim.scss
+++ b/packages/sky-toolkit-ui/components/_trim.scss
@@ -5,52 +5,6 @@
 // Imports
 @import "sky-toolkit-core/tools";
 
-// Tools
-
-// @include trim-brands()
-// ==============================================
-
-// Generate branded trim by passing maps containing gradient values
-//
-// $custom: name of bespoke gradient map
-// $gradient-groups: names of prexisting gradient groups
-// see core/settings/gradients
-//
-// Example:
-// $my-custom-gradients: (
-//   cool-brand: (
-//     0%: purple,
-//     100%: hotpink
-//   )
-// );
-// .c-my-widget {
-//   @include trim-brands($my-custom-gradients, $tv-gradients);
-// }
-//
-// Generates:
-// .c-my-widget--cool-brand .c-trim {
-//   background-image: linear-grad ient(to right, #purple 0%, #hotpink 100%);
-// }
-// .c-my-widget--tv-master .c-trim {
-// ...
-
-@mixin trim-brands($custom, $gradient-groups...) {
-
-  // Add any custom gradients to the gloabl $gradients map
-  $gradients: map-merge($gradients, $custom) !global;
-
-  // Merge all the maps into one master map
-  $grouped-maps: multi-map-merge($custom, $gradient-groups...);
-
-  // Interate though the master map to generate modifers with the
-  // appropriate gradient values
-  @each $gradient in map-keys($grouped-maps) {
-    &--#{$gradient} .c-trim {
-      @include gradient-background($gradient, horizontal);
-    }
-  }
-}
-
 // Settings
 $trim-gradients: (
   trim-fallback: (


### PR DESCRIPTION
## Description
Moves the trim mixin into tools


## Related Issue
<!-- Please link to the issue here. If an issue doesn't exist, please create one. -->

## Motivation and Context
Like dividers and panels before it, trim is both a UI component but also provides toolking to augment other components. For this to work in other applications, it needs to be available in the tools import 

## How Has This Been Tested?
<!--
  Please describe in detail how you tested your changes.

  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->


## Markup
<!-- If appropriate, please provide markup to compliment your changes. -->


## Screenshots
<!-- If appropriate, please provide screenshots. -->


## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [ ] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
