### PR TITLE
fix(core): defaulting gradient map, better namespacing

### DIFF
--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -133,8 +133,8 @@ $toolkit-tv-gradients: (
     100%: #00ffdc
   ),
   tv-entertainment: (
-    0%:   #0864aa,
-    100%: #0c80db
+    0%:   #0062a3,
+    100%: #007ac1
   ),
   tv-hd: (
     0%:   #000,

--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -4,7 +4,7 @@
 
 // Our brand and project gradients are held in maps.
 // Grouped to allow specific targeting
-$ui-gradients: (
+$toolkit-ui-gradients: (
   default: (
     0%:   #f2f2f5,
     100%: #fff
@@ -42,7 +42,7 @@ $ui-gradients: (
   ),
 ) !default;
 
-$channel-gradients: (
+$toolkit-channel-gradients: (
   sky-1: (
     0%:   #0080df,
     100%: #079ef8
@@ -89,14 +89,14 @@ $channel-gradients: (
   ),
 ) !default;
 
-$mobile-gradients: (
+$toolkit-mobile-gradients: (
   sky-mobile: (
     0%: #ff00a5,
     100%: #ff6400
   )
 ) !default;
 
-$broadband-gradients: (
+$toolkit-broadband-gradients: (
   sky-broadband: (
     0%: #6e00ff,
     100%: #ff00a5
@@ -127,7 +127,7 @@ $broadband-gradients: (
   ),
 ) !default;
 
-$tv-gradients: (
+$toolkit-tv-gradients: (
   sky-tv: (
     0%: #6e00ff,
     100%: #00ffdc
@@ -147,7 +147,7 @@ $tv-gradients: (
   ),
 ) !default;
 
-$deprecated-gradients: (
+$toolkit-deprecated-gradients: (
 sky-living: (
     0%:   #68879c,
     100%: #67a0b5
@@ -167,7 +167,7 @@ sky-living: (
 
 // Merge all the graident groups into one "master" $gradients map for global use
 // Access these values using tools from `tools/gradients`.
-$gradients: _merge-groups($ui-gradients, $channel-gradients, $tv-gradients, $broadband-gradients, $mobile-gradients, $deprecated-gradients);
+$gradients: _merge-groups($toolkit-ui-gradients, $toolkit-channel-gradients, $toolkit-tv-gradients, $toolkit-broadband-gradients, $toolkit-mobile-gradients, $toolkit-deprecated-gradients) !default;
 
 // Directional settings required for defining both prefixed and standard
 // gradients in our `tools/gradients` mixins.

--- a/packages/sky-toolkit-core/tools/_trim.scss
+++ b/packages/sky-toolkit-core/tools/_trim.scss
@@ -19,7 +19,7 @@
 //   )
 // );
 // .c-my-widget {
-//   @include trim-brands($my-custom-gradients, $tv-gradients);
+//   @include trim-brands($my-custom-gradients, $toolkit-tv-gradients);
 // }
 //
 // Generates:


### PR DESCRIPTION
<!--
                            W A R N I N G

   Please ensure you have followed our contributing guidelines before
             attempting to merge any work into the project.

  TITLE:
    Provide a general summary of your changes in the Title above.

  LABELS:
    Please add appropriate labels to your PR.
    If you've made changes to a specific package, please make sure to select
    the corresponding label.
-->

## Description
As the `$gradients` wasn't getting defaulted anymore, consumer styles would not be to map merge.
Also, the names for the groupings need to be more specific to avoid clashes as was the case with `$mobile-gradients`

## Related Issue
<!-- Please link to the issue here. If an issue doesn't exist, please create one. -->


## Motivation and Context
<!--
  Why is this change required? What problem does it solve? What program is it
  supporting (if any)?
-->


## How Has This Been Tested?
<!--
  Please describe in detail how you tested your changes.

  Include details of your testing environment, and the tests you ran to
  see how your change affects other areas of the code, etc.
-->


## Markup
<!-- If appropriate, please provide markup to compliment your changes. -->


## Screenshots
<!-- If appropriate, please provide screenshots. -->


## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [ ] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
