### PR TITLE
Proposition gradients

### DIFF
--- a/packages/sky-toolkit-core/docs/tools/trim.md
+++ b/packages/sky-toolkit-core/docs/tools/trim.md
@@ -8,5 +8,5 @@ layout: component
 
 # Trim
 
-See [sky-toolkit-ui/components/panel
+See [sky-toolkit-ui/components/trim
 ](../../../sky-toolkit-ui/docs/components/trim.md).

--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -6,7 +6,7 @@
 // ==============================================
 
 // Our brand and project gradients are held in maps.
-// Groups allow specific targeting
+// Groups allow more specific gradient sets to be consumed.
 
 $toolkit-ui-gradients: (
   default: (

--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -2,8 +2,12 @@
 // SETTINGS / #GRADIENTS
 // =============================================================================
 
+// Groups
+// ==============================================
+
 // Our brand and project gradients are held in maps.
-// Grouped to allow specific targeting
+// Groups allow specific targeting
+
 $toolkit-ui-gradients: (
   default: (
     0%:   #f2f2f5,
@@ -154,6 +158,9 @@ sky-living: (
   ),
 ) !default;
 
+// Combine
+// ==============================================
+
 // Merge all the gradient maps together - local use only
 @function _merge-groups($maps...) {
   $group: ();
@@ -168,6 +175,26 @@ sky-living: (
 // Merge all the graident groups into one "master" $gradients map for global use
 // Access these values using tools from `tools/gradients`.
 $gradients: _merge-groups($toolkit-ui-gradients, $toolkit-channel-gradients, $toolkit-tv-gradients, $toolkit-broadband-gradients, $toolkit-mobile-gradients, $toolkit-deprecated-gradients) !default;
+
+// Sets
+// ==============================================
+
+// Convenient groupings created from $gradients
+
+$toolkit-proposition-brands: (
+  sky-tv: (
+    map-get($gradients, sky-tv)
+  ),
+  sky-mobile: (
+    map-get($gradients, sky-mobile)
+  ),
+  sky-broadband: (
+    map-get($gradients, sky-broadband)
+  )
+);
+
+// Directions
+// ==============================================
 
 // Directional settings required for defining both prefixed and standard
 // gradients in our `tools/gradients` mixins.

--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -176,10 +176,10 @@ sky-living: (
 // Access these values using tools from `tools/gradients`.
 $gradients: _merge-groups($toolkit-ui-gradients, $toolkit-channel-gradients, $toolkit-tv-gradients, $toolkit-broadband-gradients, $toolkit-mobile-gradients, $toolkit-deprecated-gradients) !default;
 
-// Sets
+// Regroup
 // ==============================================
 
-// Convenient groupings created from $gradients
+// Convenient groupings of gradients already defined and part of $gradients
 
 $toolkit-proposition-brands: (
   sky-tv: (

--- a/packages/sky-toolkit-ui/docs/components/trim.md
+++ b/packages/sky-toolkit-ui/docs/components/trim.md
@@ -17,7 +17,7 @@ layout: component
 <div class="c-trim u-margin-bottom"></div>
 ```
 ## Branded Example
-See trim.scss for how to use the `trim-brands()` mixin to generate bepoke brands
+See [sky-toolkit-core/tools/_trim.scss](../../../sky-toolkit-core/tools/_trim.scss). for how to use the `trim-brands()` mixin to generate bepoke brands
 and access values from the `$gradients` groups.
 For example:
 


### PR DESCRIPTION
<!--
                            W A R N I N G

   Please ensure you have followed our contributing guidelines before
             attempting to merge any work into the project.

  TITLE:
    Provide a general summary of your changes in the Title above.

  LABELS:
    Please add appropriate labels to your PR.
    If you've made changes to a specific package, please make sure to select
    the corresponding label.
-->

## Description
- Adds the concept of "sets" to gradients to allow convenient access to alternative groupings of gradients.
- Couple of minor improves to trim READMEs and Gradient comments

## Motivation and Context
The combination of Sky TV, Mobile Broadband is quite common but means consumers either have to redeclare the mappings or generate a lot more gradient styles than they need


## How Has This Been Tested?
used `preview` to generate trims with `@include trim-brands($toolkit-proposition-brands);`

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [x] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
