### PR TITLE
fix(toolkit-core): remove local font src reference

### DIFF
--- a/packages/sky-toolkit-core/generic/_font-face.scss
+++ b/packages/sky-toolkit-core/generic/_font-face.scss
@@ -12,8 +12,7 @@
   @font-face {
     font-family: "Sky Text";
     font-display: fallback;
-    src: local("Sky Text"),
-         url("//static.skyassets.com/fonts/sky-regular.woff2") format("woff2"),
+    src: url("//static.skyassets.com/fonts/sky-regular.woff2") format("woff2"),
          url("//static.skyassets.com/fonts/sky-regular.woff") format("woff");
   }
 
@@ -21,8 +20,7 @@
     font-family: "Sky Text";
     font-weight: bold;
     font-display: fallback;
-    src: local("Sky Text"),
-         url("//static.skyassets.com/fonts/sky-medium.woff2") format("woff2"),
+    src: url("//static.skyassets.com/fonts/sky-medium.woff2") format("woff2"),
          url("//static.skyassets.com/fonts/sky-medium.woff") format("woff");
   }
 }


### PR DESCRIPTION
## Description

Removes the reference to local Sky Text files in the font face declarations.

## Motivation and Context

Was causing font certain font weights to not be loaded on machines with Sky Text installed.

## How Has This Been Tested?

Ran preview locally and correct weights were displayed.

## Screenshots

![image](https://user-images.githubusercontent.com/38754489/64441303-83ce9780-d0c5-11e9-819c-6e80fd6b9d7c.png)


## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [x] Bug Fix *(non-breaking change which fixes an issue)*
- [ ] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [ ] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
