### PR TITLE
Add new gradient for sky crime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/*.css
 npm-debug.log
 lerna-debug.log
 .vscode/
+.idea/

--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -94,6 +94,10 @@ $toolkit-channel-gradients: (
   challenge: (
     0%: #ff5200,
     100%: #ff5200
+  ),
+  sky-crime: (
+    0%: #31566b,
+    100%: #05060c
   )
 ) !default;
 

--- a/packages/sky-toolkit-ui/components/_tile.scss
+++ b/packages/sky-toolkit-ui/components/_tile.scss
@@ -24,7 +24,7 @@ $tile-sponsor-padding: $tile-border-width + 5px;
 // Array of gradient names to generate specific brand themes for Tiles.
 // By default all themes are generated.
 // You can output specific themes by overwriting `$tile-themes`.
-$tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-box-sets", "sky-cinema", "sky-kids", "sky-living", "sky-witness", "sky-news", "sky-sports", "sky-store", "ultimate-on-demand", "sky-mobile", "pick", "challenge" !default;
+$tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-box-sets", "sky-cinema", "sky-kids", "sky-living", "sky-witness", "sky-news", "sky-sports", "sky-store", "ultimate-on-demand", "sky-mobile", "pick", "challenge", "sky-crime" !default;
 
 // Dependencies (Optional)
 // =========================================== */


### PR DESCRIPTION
## Description
This PR adds a gradient for a new Sky channel - sky-crime.

## Related Issue
One of several PRs for this JIRA ticket https://cbsjira.bskyb.com/browse/DCLHOME-608

## Motivation and Context
To make the gradient available for use on the Find and Watch pages of sky.com.

## Types of Changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Internal *(framework-only)*
- [ ] Bug Fix *(non-breaking change which fixes an issue)*
- [X] New Feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*

## Browser Support

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] IE9
- [ ] IE10
- [ ] IE11
- [ ] Opera
- [ ] Safari
- [ ] Mobile Devices
- [ ] Screen-readers (e.g. JAWS, Apple VoiceOver)

## Checklist

- [ ] All **design and code** conforms to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions).
- [ ] New functions and mixins have appropriate tests.
- [X] All new and existing tests passed.
- [ ] I have added instructions on how to test my changes.
