### PR TITLE
Adds support for Sky Comedy channel

### DIFF
--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -98,6 +98,10 @@ $toolkit-channel-gradients: (
   sky-crime: (
     0%: #31566b,
     100%: #05060c
+  ),
+  sky-comedy: (
+    0%: #ff8200,
+    100%: #ff8200
   )
 ) !default;
 

--- a/packages/sky-toolkit-ui/components/_tile.scss
+++ b/packages/sky-toolkit-ui/components/_tile.scss
@@ -24,7 +24,7 @@ $tile-sponsor-padding: $tile-border-width + 5px;
 // Array of gradient names to generate specific brand themes for Tiles.
 // By default all themes are generated.
 // You can output specific themes by overwriting `$tile-themes`.
-$tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-box-sets", "sky-cinema", "sky-kids", "sky-living", "sky-witness", "sky-news", "sky-sports", "sky-store", "ultimate-on-demand", "sky-mobile", "pick", "challenge", "sky-crime" !default;
+$tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-box-sets", "sky-cinema", "sky-kids", "sky-living", "sky-witness", "sky-news", "sky-sports", "sky-store", "ultimate-on-demand", "sky-mobile", "pick", "challenge", "sky-crime", "sky-comedy" !default;
 
 // Dependencies (Optional)
 // =========================================== */


### PR DESCRIPTION
## Description (The what)
Adds tile hover support for a new Sky Comedy channel, going live Mid January 2020

## Motivation and Context (The why)
New sky channel

## How / where can this be tested?
<!-- Why not fireup a [Codepen](https://codepen.io/)? -->

## Browser support checklist
<!-- Use the latest version of each browser, OS and/or software -->

### Mobile
- [ ] Safari on iOS
- [ ] Chrome on Android

### Desktop
- [ ] Latest Chrome
- [ ] Latest Edge
- [ ] IE11

### Assistive Technology
- [ ] NVDA on Chrome or Firefox
- [ ] VoiceOver on iOS
