### PR TITLE
Add new channel gradients for Sky Nature and Documentaries

### DIFF
--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -102,6 +102,14 @@ $toolkit-channel-gradients: (
   sky-comedy: (
     0%: #ff8200,
     100%: #ff8200
+  ),
+  sky-documentaries: (
+    0%: #E90000,
+    100%: #E90000
+  ),
+  sky-nature: (
+    0%: #347900,
+    100%: #347900
   )
 ) !default;
 

--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -104,8 +104,8 @@ $toolkit-channel-gradients: (
     100%: #ff8200
   ),
   sky-documentaries: (
-    0%: #E90000,
-    100%: #E90000
+    0%: #e90000,
+    100%: #e90000
   ),
   sky-nature: (
     0%: #347900,


### PR DESCRIPTION
## Description (The what)
Adds two new gradients for Sky Nature and Sky Documentaries

## Motivation and Context (The why)
Required for two new channels for May 27th which we're adding to the legacy stack under https://www.sky.com/watch/channel/sky-nature and https://www.sky.com/watch/channel/sky-documentaries

## How / where can this be tested?
<!-- Why not fireup a [Codepen](https://codepen.io/)? -->

## Browser support checklist
<!-- Use the latest version of each browser, OS and/or software -->

### Mobile
- [ ] Safari on iOS
- [ ] Chrome on Android

### Desktop
- [ ] Latest Chrome
- [ ] Latest Edge
- [ ] IE11

### Assistive Technology
- [ ] NVDA on Chrome or Firefox
- [ ] VoiceOver on iOS
