### PR TITLE
Add gradients for sky nature and docs

### DIFF
--- a/packages/sky-toolkit-ui/components/_tile.scss
+++ b/packages/sky-toolkit-ui/components/_tile.scss
@@ -24,7 +24,7 @@ $tile-sponsor-padding: $tile-border-width + 5px;
 // Array of gradient names to generate specific brand themes for Tiles.
 // By default all themes are generated.
 // You can output specific themes by overwriting `$tile-themes`.
-$tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-box-sets", "sky-cinema", "sky-kids", "sky-living", "sky-witness", "sky-news", "sky-sports", "sky-store", "ultimate-on-demand", "sky-mobile", "pick", "challenge", "sky-crime", "sky-comedy" !default;
+$tile-themes: "sky-1", "sky-account", "sky-atlantic", "sky-arts", "sky-box-sets", "sky-cinema", "sky-kids", "sky-living", "sky-witness", "sky-news", "sky-sports", "sky-store", "ultimate-on-demand", "sky-mobile", "pick", "challenge", "sky-crime", "sky-comedy", "sky-nature", "sky-documentaries" !default;
 
 // Dependencies (Optional)
 // =========================================== */


### PR DESCRIPTION
## Description (The what)
Adds missing support for `sky-nature` and `sky-documentaries` gradients

## Motivation and Context (The why)
To add gradients to use on tile hover on pages on the legacy Find & Watch area of the site (i.e. to make https://www.sky.com/watch/channel/sky-nature and https://www.sky.com/watch/channel/sky-documentaries work like https://www.sky.com/watch/channel/sky-comedy)

## Browser support checklist
<!-- Use the latest version of each browser, OS and/or software -->

### Mobile
- [ ] Safari on iOS
- [ ] Chrome on Android

### Desktop
- [ ] Latest Chrome
- [ ] Latest Edge
- [ ] IE11

### Assistive Technology
- [ ] NVDA on Chrome or Firefox
- [ ] VoiceOver on iOS
