### PR TITLE
Updating gradient for sky spectrum.

### DIFF
--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -36,7 +36,7 @@ $toolkit-ui-gradients: (
   ),
   sky-spectrum: (
     0%:  #ff9e00,
-    35%: #ff00,
+    35%: #ff0000,
     60%: #b5007d,
     85%: #21429c,
     100%: #0071ff

--- a/packages/sky-toolkit-core/settings/_gradients.scss
+++ b/packages/sky-toolkit-core/settings/_gradients.scss
@@ -36,7 +36,7 @@ $toolkit-ui-gradients: (
   ),
   sky-spectrum: (
     0%:  #ff9e00,
-    35%: #ff0000,
+    35%: #ff0,
     60%: #b5007d,
     85%: #21429c,
     100%: #0071ff


### PR DESCRIPTION
<!-- Thanks for contributing to Sky Toolkit!

Please refer to the [Design Contribution Guidelines](https://github.com/sky-uk/toolkit/blob/develop/CONTRIBUTING.md#design-contributions) for more information about how to get involved

-->

## Description (The what)
This updates the gradient for the sky spectrum, we were supplied the wrong hex

## Motivation and Context (The why)

To keep the branding up to date.

## How / where can this be tested?
<!-- Why not fireup a [Codepen](https://codepen.io/)? -->

## Browser support checklist
<!-- Use the latest version of each browser, OS and/or software -->

### Mobile
- [ ] Safari on iOS
- [ ] Chrome on Android

### Desktop
- [ ] Latest Chrome
- [ ] Latest Edge
- [ ] IE11

### Assistive Technology
- [ ] NVDA on Chrome or Firefox
- [ ] VoiceOver on iOS
